### PR TITLE
Fix spring bean name

### DIFF
--- a/vaadin-spring/src/main/java/com/vaadin/spring/annotation/SpringUI.java
+++ b/vaadin-spring/src/main/java/com/vaadin/spring/annotation/SpringUI.java
@@ -61,7 +61,7 @@ public @interface SpringUI {
      * map the UI to the root of the servlet. Within a web application, there
      * must not be multiple UI sub classes with the same path.
      *
-     * By default, and if the special value {@link #USE_CONVENTIONS} is used,
+     * By default, and if the special value "" is used,
      * the mapping is derived from the simple name of the class. A class
      * WelcomeVaadin is going to be bound to "/welcome-vaadin" uri. A class
      * SampleApplicationUI will be bound to "/sample-application".
@@ -69,12 +69,6 @@ public @interface SpringUI {
      * To override the default behavior, see
      * {@link SpringAwareUIProvider#deriveMappingForUI()}.
      */
-    String value() default USE_CONVENTIONS;
-
-    /**
-     * USE_CONVENTIONS is treated as a special case that will cause the
-     * automatic UI mapping to occur.
-     */
-    public final static String USE_CONVENTIONS = "USE CONVENTIONS";
+    String value() default "";
 
 }

--- a/vaadin-spring/src/main/java/com/vaadin/spring/annotation/SpringUI.java
+++ b/vaadin-spring/src/main/java/com/vaadin/spring/annotation/SpringUI.java
@@ -71,4 +71,5 @@ public @interface SpringUI {
      */
     String value() default "";
 
+    boolean root() default false;
 }

--- a/vaadin-spring/src/main/java/com/vaadin/spring/internal/Conventions.java
+++ b/vaadin-spring/src/main/java/com/vaadin/spring/internal/Conventions.java
@@ -34,7 +34,7 @@ public final class Conventions {
     public static String deriveMappingForUI(Class<?> beanClass,
             SpringUI annotation) {
         String mapping = annotation.value();
-        if (!SpringUI.USE_CONVENTIONS.equals(mapping)) {
+        if (!mapping.equals("")) {
             return mapping;
         } else {
             // derive mapping from classname
@@ -47,17 +47,20 @@ public final class Conventions {
 
     public static String deriveMappingForView(Class<?> beanClass,
             SpringView annotation) {
-        if (annotation != null
-                && !SpringView.USE_CONVENTIONS.equals(annotation.value())) {
-            return annotation.value();
-        } else {
-            // derive mapping from classname
-            // do not use proxy class names
-            Class<?> realBeanClass = ClassUtils.getUserClass(beanClass);
-            String mapping = realBeanClass.getSimpleName().replaceFirst(
-                    "View$", "");
-            return upperCamelToLowerHyphen(mapping);
+        if (annotation != null) {
+            if(annotation.index()){
+                return "";
+            }
+            if(!annotation.value().equals("")) {
+                return annotation.value();
+            }
         }
+        // derive mapping from classname
+        // do not use proxy class names
+        Class<?> realBeanClass = ClassUtils.getUserClass(beanClass);
+        String mapping = realBeanClass.getSimpleName().replaceFirst(
+                "View$", "");
+        return upperCamelToLowerHyphen(mapping);
     }
 
     public static String upperCamelToLowerHyphen(String string) {

--- a/vaadin-spring/src/main/java/com/vaadin/spring/internal/Conventions.java
+++ b/vaadin-spring/src/main/java/com/vaadin/spring/internal/Conventions.java
@@ -34,6 +34,9 @@ public final class Conventions {
     public static String deriveMappingForUI(Class<?> beanClass,
             SpringUI annotation) {
         String mapping = annotation.value();
+        if(annotation.root()){
+            return "";
+        }
         if (!mapping.equals("")) {
             return mapping;
         } else {
@@ -48,7 +51,7 @@ public final class Conventions {
     public static String deriveMappingForView(Class<?> beanClass,
             SpringView annotation) {
         if (annotation != null) {
-            if(annotation.index()){
+            if(annotation.root()){
                 return "";
             }
             if(!annotation.value().equals("")) {

--- a/vaadin-spring/src/main/java/com/vaadin/spring/navigator/annotation/SpringView.java
+++ b/vaadin-spring/src/main/java/com/vaadin/spring/navigator/annotation/SpringView.java
@@ -70,20 +70,16 @@ public @interface SpringView {
      * can be multiple views with the same name as long as they belong to
      * separate UI subclasses.
      *
-     * If the default value {@link #USE_CONVENTIONS} is used, the name of the
+     * If the default value "" is used, the name of the
      * view is derived from the class name so that e.g. UserDetailView becomes
      * "user-detail". Although auto-generated view names are supported, using
      * explicit naming of views is strongly recommended.
      *
      * @see #ui()
      */
-    String value() default USE_CONVENTIONS;
+    String value() default "";
 
-    /**
-     * USE_CONVENTIONS is treated as a special case that will cause the
-     * automatic View mapping to occur.
-     */
-    public static final String USE_CONVENTIONS = "USE CONVENTIONS";
+    boolean index() default false;
 
     /**
      * By default, the view will be available for all UI subclasses in the

--- a/vaadin-spring/src/main/java/com/vaadin/spring/navigator/annotation/SpringView.java
+++ b/vaadin-spring/src/main/java/com/vaadin/spring/navigator/annotation/SpringView.java
@@ -79,7 +79,7 @@ public @interface SpringView {
      */
     String value() default "";
 
-    boolean index() default false;
+    boolean root() default false;
 
     /**
      * By default, the view will be available for all UI subclasses in the

--- a/vaadin-spring/src/test/java/com/vaadin/spring/demo/DemoUI.java
+++ b/vaadin-spring/src/test/java/com/vaadin/spring/demo/DemoUI.java
@@ -1,0 +1,35 @@
+package com.vaadin.spring.demo;
+
+import com.vaadin.navigator.View;
+import com.vaadin.navigator.ViewChangeListener;
+import com.vaadin.server.VaadinRequest;
+import com.vaadin.spring.annotation.SpringUI;
+import com.vaadin.spring.navigator.annotation.SpringView;
+import com.vaadin.ui.CustomComponent;
+import com.vaadin.ui.UI;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Created by fireflyc@gmail.com on 15/3/6.
+ */
+@SpringUI
+public class DemoUI extends UI {
+    @Override
+    protected void init(VaadinRequest request) {
+
+    }
+
+    @SpringView
+    static public class DemoView extends CustomComponent implements View {
+        @Override
+        public void enter(ViewChangeListener.ViewChangeEvent event) {
+
+        }
+    }
+
+    @Configuration
+    @ComponentScan("com.vaadin.spring.demo")
+    static public class AutConfig {
+    }
+}

--- a/vaadin-spring/src/test/java/com/vaadin/spring/demo/SpringTest.java
+++ b/vaadin-spring/src/test/java/com/vaadin/spring/demo/SpringTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2015 The original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.vaadin.spring.demo;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.context.ApplicationContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+/**
+ * Created by fireflyc@gmail.com on 15/3/6.
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(classes = DemoUI.AutConfig.class)
+public class SpringTest {
+
+    @Test
+    public void testLoadSystem(){
+
+    }
+}

--- a/vaadin-spring/src/test/java/com/vaadin/spring/internal/ConventionsTest.java
+++ b/vaadin-spring/src/test/java/com/vaadin/spring/internal/ConventionsTest.java
@@ -41,7 +41,7 @@ public class ConventionsTest {
     public static class DefaultUI {
     }
 
-    @SpringUI("")
+    @SpringUI(root=true)
     public static class RootUI {
     }
 

--- a/vaadin-spring/src/test/java/com/vaadin/spring/internal/ConventionsTest.java
+++ b/vaadin-spring/src/test/java/com/vaadin/spring/internal/ConventionsTest.java
@@ -33,7 +33,7 @@ public class ConventionsTest {
     public static class AnnotationUI {
     }
 
-    @SpringUI(SpringUI.USE_CONVENTIONS)
+    @SpringUI("/convention")
     public static class ConventionUI {
     }
 


### PR DESCRIPTION
Use magic number indicates whether or not the is not a good idea for the Root, if there are multiple View will appear the following exception information:


org.springframework.beans.factory.BeanDefinitionStoreException: Failed to parse configuration class [com.vaadin.spring.demo.DemoUI$AutConfig]; nested exception is org.springframework.context.annotation.ConflictingBeanDefinitionException: Annotation-specified bean name 'USE CONVENTIONS' for bean class [com.vaadin.spring.demo.DemoUI] conflicts with existing, non-compatible bean definition of same name and class [com.vaadin.spring.demo.DemoUI$DemoView]
	at org.springframework.context.annotation.ConfigurationClassParser.parse(ConfigurationClassParser.java:177)
	at org.springframework.context.annotation.ConfigurationClassPostProcessor.processConfigBeanDefinitions(ConfigurationClassPostProcessor.java:306)
	at org.springframework.context.annotation.ConfigurationClassPostProcessor.postProcessBeanDefinitionRegistry(ConfigurationClassPostProcessor.java:239)
	at org.springframework.context.support.PostProcessorRegistrationDelegate.invokeBeanDefinitionRegistryPostProcessors(PostProcessorRegistrationDelegate.java:254)
	at org.springframework.context.support.PostProcessorRegistrationDelegate.invokeBeanFactoryPostProcessors(PostProcessorRegistrationDelegate.java:94)
	at org.springframework.context.support.AbstractApplicationContext.invokeBeanFactoryPostProcessors(AbstractApplicationContext.java:606)
	at org.springframework.context.support.AbstractApplicationContext.refresh(AbstractApplicationContext.java:462)
	at org.springframework.test.context.support.AbstractGenericContextLoader.loadContext(AbstractGenericContextLoader.java:125)
	at org.springframework.test.context.support.AbstractGenericContextLoader.loadContext(AbstractGenericContextLoader.java:60)
	at org.springframework.test.context.support.AbstractDelegatingSmartContextLoader.delegateLoading(AbstractDelegatingSmartContextLoader.java:109)
	at org.springframework.test.context.support.AbstractDelegatingSmartContextLoader.loadContext(AbstractDelegatingSmartContextLoader.java:261)
	at org.springframework.test.context.DefaultCacheAwareContextLoaderDelegate.loadContextInternal(DefaultCacheAwareContextLoaderDelegate.java:68)
	at org.springframework.test.context.DefaultCacheAwareContextLoaderDelegate.loadContext(DefaultCacheAwareContextLoaderDelegate.java:86)
	at org.springframework.test.context.DefaultTestContext.getApplicationContext(DefaultTestContext.java:72)
	at org.springframework.test.context.support.DependencyInjectionTestExecutionListener.injectDependencies(DependencyInjectionTestExecutionListener.java:117)
	at org.springframework.test.context.support.DependencyInjectionTestExecutionListener.prepareTestInstance(DependencyInjectionTestExecutionListener.java:83)
	at org.springframework.test.context.TestContextManager.prepareTestInstance(TestContextManager.java:212)
	at org.springframework.test.context.junit4.SpringJUnit4ClassRunner.createTest(SpringJUnit4ClassRunner.java:200)
	at org.springframework.test.context.junit4.SpringJUnit4ClassRunner$1.runReflectiveCall(SpringJUnit4ClassRunner.java:252)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.springframework.test.context.junit4.SpringJUnit4ClassRunner.methodBlock(SpringJUnit4ClassRunner.java:254)
	at org.springframework.test.context.junit4.SpringJUnit4ClassRunner.runChild(SpringJUnit4ClassRunner.java:217)
	at org.springframework.test.context.junit4.SpringJUnit4ClassRunner.runChild(SpringJUnit4ClassRunner.java:83)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:238)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:63)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:236)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:53)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:229)
	at org.springframework.test.context.junit4.statements.RunBeforeTestClassCallbacks.evaluate(RunBeforeTestClassCallbacks.java:61)
	at org.springframework.test.context.junit4.statements.RunAfterTestClassCallbacks.evaluate(RunAfterTestClassCallbacks.java:68)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:309)
	at org.springframework.test.context.junit4.SpringJUnit4ClassRunner.run(SpringJUnit4ClassRunner.java:163)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:160)
	at com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner.java:74)
	at com.intellij.rt.execution.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:211)
	at com.intellij.rt.execution.junit.JUnitStarter.main(JUnitStarter.java:67)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:483)
	at com.intellij.rt.execution.application.AppMain.main(AppMain.java:134)
Caused by: org.springframework.context.annotation.ConflictingBeanDefinitionException: Annotation-specified bean name 'USE CONVENTIONS' for bean class [com.vaadin.spring.demo.DemoUI] conflicts with existing, non-compatible bean definition of same name and class [com.vaadin.spring.demo.DemoUI$DemoView]
	at org.springframework.context.annotation.ClassPathBeanDefinitionScanner.checkCandidate(ClassPathBeanDefinitionScanner.java:320)
	at org.springframework.context.annotation.ClassPathBeanDefinitionScanner.doScan(ClassPathBeanDefinitionScanner.java:259)
	at org.springframework.context.annotation.ComponentScanAnnotationParser.parse(ComponentScanAnnotationParser.java:140)
	at org.springframework.context.annotation.ConfigurationClassParser.doProcessConfigurationClass(ConfigurationClassParser.java:262)
	at org.springframework.context.annotation.ConfigurationClassParser.processConfigurationClass(ConfigurationClassParser.java:226)
	at org.springframework.context.annotation.ConfigurationClassParser.parse(ConfigurationClassParser.java:193)
	at org.springframework.context.annotation.ConfigurationClassParser.parse(ConfigurationClassParser.java:163)
	... 40 more

三月 08, 2015 10:50:37 上午 org.springframework.test.context.TestContextManager prepareTestInstance
严重: Caught exception while allowing TestExecutionListener [org.springframework.test.context.support.DependencyInjectionTestExecutionListener@2f7c7260] to prepare test instance [com.vaadin.spring.demo.SpringTest@5e955596]
java.lang.IllegalStateException: Failed to load ApplicationContext
	at org.springframework.test.context.DefaultCacheAwareContextLoaderDelegate.loadContext(DefaultCacheAwareContextLoaderDelegate.java:94)
	at org.springframework.test.context.DefaultTestContext.getApplicationContext(DefaultTestContext.java:72)
	at org.springframework.test.context.support.DependencyInjectionTestExecutionListener.injectDependencies(DependencyInjectionTestExecutionListener.java:117)
	at org.springframework.test.context.support.DependencyInjectionTestExecutionListener.prepareTestInstance(DependencyInjectionTestExecutionListener.java:83)
	at org.springframework.test.context.TestContextManager.prepareTestInstance(TestContextManager.java:212)
	at org.springframework.test.context.junit4.SpringJUnit4ClassRunner.createTest(SpringJUnit4ClassRunner.java:200)
	at org.springframework.test.context.junit4.SpringJUnit4ClassRunner$1.runReflectiveCall(SpringJUnit4ClassRunner.java:252)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.springframework.test.context.junit4.SpringJUnit4ClassRunner.methodBlock(SpringJUnit4ClassRunner.java:254)
	at org.springframework.test.context.junit4.SpringJUnit4ClassRunner.runChild(SpringJUnit4ClassRunner.java:217)
	at org.springframework.test.context.junit4.SpringJUnit4ClassRunner.runChild(SpringJUnit4ClassRunner.java:83)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:238)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:63)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:236)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:53)

java.lang.IllegalStateException: Failed to load ApplicationContext
	at org.springframework.test.context.DefaultCacheAwareContextLoaderDelegate.loadContext(DefaultCacheAwareContextLoaderDelegate.java:94)
	at org.springframework.test.context.DefaultTestContext.getApplicationContext(DefaultTestContext.java:72)
	at org.springframework.test.context.support.DependencyInjectionTestExecutionListener.injectDependencies(DependencyInjectionTestExecutionListener.java:117)
	at org.springframework.test.context.support.DependencyInjectionTestExecutionListener.prepareTestInstance(DependencyInjectionTestExecutionListener.java:83)
	at org.springframework.test.context.TestContextManager.prepareTestInstance(TestContextManager.java:212)
	at org.springframework.test.context.junit4.SpringJUnit4ClassRunner.createTest(SpringJUnit4ClassRunner.java:200)
	at org.springframework.test.context.junit4.SpringJUnit4ClassRunner$1.runReflectiveCall(SpringJUnit4ClassRunner.java:252)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.springframework.test.context.junit4.SpringJUnit4ClassRunner.methodBlock(SpringJUnit4ClassRunner.java:254)
	at org.springframework.test.context.junit4.SpringJUnit4ClassRunner.runChild(SpringJUnit4ClassRunner.java:217)
	at org.springframework.test.context.junit4.SpringJUnit4ClassRunner.runChild(SpringJUnit4ClassRunner.java:83)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:238)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:63)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:236)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:53)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:229)
	at org.springframework.test.context.junit4.statements.RunBeforeTestClassCallbacks.evaluate(RunBeforeTestClassCallbacks.java:61)
	at org.springframework.test.context.junit4.statements.RunAfterTestClassCallbacks.evaluate(RunAfterTestClassCallbacks.java:68)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:309)
	at org.springframework.test.context.junit4.SpringJUnit4ClassRunner.run(SpringJUnit4ClassRunner.java:163)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:160)
	at com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner.java:74)
	at com.intellij.rt.execution.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:211)
	at com.intellij.rt.execution.junit.JUnitStarter.main(JUnitStarter.java:67)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at com.intellij.rt.execution.application.AppMain.main(AppMain.java:134)
Caused by: org.springframework.beans.factory.BeanDefinitionStoreException: Failed to parse configuration class [com.vaadin.spring.demo.DemoUI$AutConfig]; nested exception is org.springframework.context.annotation.ConflictingBeanDefinitionException: Annotation-specified bean name 'USE CONVENTIONS' for bean class [com.vaadin.spring.demo.DemoUI] conflicts with existing, non-compatible bean definition of same name and class [com.vaadin.spring.demo.DemoUI$DemoView]
	at org.springframework.context.annotation.ConfigurationClassParser.parse(ConfigurationClassParser.java:177)
	at org.springframework.context.annotation.ConfigurationClassPostProcessor.processConfigBeanDefinitions(ConfigurationClassPostProcessor.java:306)
	at org.springframework.context.annotation.ConfigurationClassPostProcessor.postProcessBeanDefinitionRegistry(ConfigurationClassPostProcessor.java:239)
	at org.springframework.context.support.PostProcessorRegistrationDelegate.invokeBeanDefinitionRegistryPostProcessors(PostProcessorRegistrationDelegate.java:254)
	at org.springframework.context.support.PostProcessorRegistrationDelegate.invokeBeanFactoryPostProcessors(PostProcessorRegistrationDelegate.java:94)
	at org.springframework.context.support.AbstractApplicationContext.invokeBeanFactoryPostProcessors(AbstractApplicationContext.java:606)
	at org.springframework.context.support.AbstractApplicationContext.refresh(AbstractApplicationContext.java:462)
	at org.springframework.test.context.support.AbstractGenericContextLoader.loadContext(AbstractGenericContextLoader.java:125)
	at org.springframework.test.context.support.AbstractGenericContextLoader.loadContext(AbstractGenericContextLoader.java:60)
	at org.springframework.test.context.support.AbstractDelegatingSmartContextLoader.delegateLoading(AbstractDelegatingSmartContextLoader.java:109)
	at org.springframework.test.context.support.AbstractDelegatingSmartContextLoader.loadContext(AbstractDelegatingSmartContextLoader.java:261)
	at org.springframework.test.context.DefaultCacheAwareContextLoaderDelegate.loadContextInternal(DefaultCacheAwareContextLoaderDelegate.java:68)
	at org.springframework.test.context.DefaultCacheAwareContextLoaderDelegate.loadContext(DefaultCacheAwareContextLoaderDelegate.java:86)
	... 28 more
Caused by: org.springframework.context.annotation.ConflictingBeanDefinitionException: Annotation-specified bean name 'USE CONVENTIONS' for bean class [com.vaadin.spring.demo.DemoUI] conflicts with existing, non-compatible bean definition of same name and class [com.vaadin.spring.demo.DemoUI$DemoView]
	at org.springframework.context.annotation.ClassPathBeanDefinitionScanner.checkCandidate(ClassPathBeanDefinitionScanner.java:320)
	at org.springframework.context.annotation.ClassPathBeanDefinitionScanner.doScan(ClassPathBeanDefinitionScanner.java:259)
	at org.springframework.context.annotation.ComponentScanAnnotationParser.parse(ComponentScanAnnotationParser.java:140)
	at org.springframework.context.annotation.ConfigurationClassParser.doProcessConfigurationClass(ConfigurationClassParser.java:262)
	at org.springframework.context.annotation.ConfigurationClassParser.processConfigurationClass(ConfigurationClassParser.java:226)
	at org.springframework.context.annotation.ConfigurationClassParser.parse(ConfigurationClassParser.java:193)
	at org.springframework.context.annotation.ConfigurationClassParser.parse(ConfigurationClassParser.java:163)
	... 40 more

三月 08, 2015 10:50:37 上午 org.springframework.context.support.GenericApplicationContext prepareRefresh
信息: Refreshing org.springframework.context.support.GenericApplicationContext@77b52d12: startup date [Sun Mar 08 10:50:37 CST 2015]; root of context hierarchy
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:229)
	at org.springframework.test.context.junit4.statements.RunBeforeTestClassCallbacks.evaluate(RunBeforeTestClassCallbacks.java:61)
	at org.springframework.test.context.junit4.statements.RunAfterTestClassCallbacks.evaluate(RunAfterTestClassCallbacks.java:68)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:309)
	at org.springframework.test.context.junit4.SpringJUnit4ClassRunner.run(SpringJUnit4ClassRunner.java:163)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:160)
	at com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner.java:74)
	at com.intellij.rt.execution.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:211)
	at com.intellij.rt.execution.junit.JUnitStarter.main(JUnitStarter.java:67)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:483)
	at com.intellij.rt.execution.application.AppMain.main(AppMain.java:134)
Caused by: org.springframework.beans.factory.BeanDefinitionStoreException: Failed to parse configuration class [com.vaadin.spring.demo.DemoUI$AutConfig]; nested exception is org.springframework.context.annotation.ConflictingBeanDefinitionException: Annotation-specified bean name 'USE CONVENTIONS' for bean class [com.vaadin.spring.demo.DemoUI] conflicts with existing, non-compatible bean definition of same name and class [com.vaadin.spring.demo.DemoUI$DemoView]
	at org.springframework.context.annotation.ConfigurationClassParser.parse(ConfigurationClassParser.java:177)
	at org.springframework.context.annotation.ConfigurationClassPostProcessor.processConfigBeanDefinitions(ConfigurationClassPostProcessor.java:306)
	at org.springframework.context.annotation.ConfigurationClassPostProcessor.postProcessBeanDefinitionRegistry(ConfigurationClassPostProcessor.java:239)
	at org.springframework.context.support.PostProcessorRegistrationDelegate.invokeBeanDefinitionRegistryPostProcessors(PostProcessorRegistrationDelegate.java:254)
	at org.springframework.context.support.PostProcessorRegistrationDelegate.invokeBeanFactoryPostProcessors(PostProcessorRegistrationDelegate.java:94)
	at org.springframework.context.support.AbstractApplicationContext.invokeBeanFactoryPostProcessors(AbstractApplicationContext.java:606)
	at org.springframework.context.support.AbstractApplicationContext.refresh(AbstractApplicationContext.java:462)
	at org.springframework.test.context.support.AbstractGenericContextLoader.loadContext(AbstractGenericContextLoader.java:125)
	at org.springframework.test.context.support.AbstractGenericContextLoader.loadContext(AbstractGenericContextLoader.java:60)
	at org.springframework.test.context.support.AbstractDelegatingSmartContextLoader.delegateLoading(AbstractDelegatingSmartContextLoader.java:109)
	at org.springframework.test.context.support.AbstractDelegatingSmartContextLoader.loadContext(AbstractDelegatingSmartContextLoader.java:261)
	at org.springframework.test.context.DefaultCacheAwareContextLoaderDelegate.loadContextInternal(DefaultCacheAwareContextLoaderDelegate.java:68)
	at org.springframework.test.context.DefaultCacheAwareContextLoaderDelegate.loadContext(DefaultCacheAwareContextLoaderDelegate.java:86)
	... 28 more
Caused by: org.springframework.context.annotation.ConflictingBeanDefinitionException: Annotation-specified bean name 'USE CONVENTIONS' for bean class [com.vaadin.spring.demo.DemoUI] conflicts with existing, non-compatible bean definition of same name and class [com.vaadin.spring.demo.DemoUI$DemoView]
	at org.springframework.context.annotation.ClassPathBeanDefinitionScanner.checkCandidate(ClassPathBeanDefinitionScanner.java:320)
	at org.springframework.context.annotation.ClassPathBeanDefinitionScanner.doScan(ClassPathBeanDefinitionScanner.java:259)
	at org.springframework.context.annotation.ComponentScanAnnotationParser.parse(ComponentScanAnnotationParser.java:140)
	at org.springframework.context.annotation.ConfigurationClassParser.doProcessConfigurationClass(ConfigurationClassParser.java:262)
	at org.springframework.context.annotation.ConfigurationClassParser.processConfigurationClass(ConfigurationClassParser.java:226)
	at org.springframework.context.annotation.ConfigurationClassParser.parse(ConfigurationClassParser.java:193)
	at org.springframework.context.annotation.ConfigurationClassParser.parse(ConfigurationClassParser.java:163)
	... 40 more


Process finished with exit code 255
