### PR TITLE
Automatically configure navigator based on @ViewContainer bean

### DIFF
--- a/vaadin-spring/src/main/java/com/vaadin/spring/annotation/ViewContainer.java
+++ b/vaadin-spring/src/main/java/com/vaadin/spring/annotation/ViewContainer.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2015 The original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.vaadin.spring.annotation;
 
 import static java.lang.annotation.ElementType.TYPE;

--- a/vaadin-spring/src/main/java/com/vaadin/spring/annotation/ViewContainer.java
+++ b/vaadin-spring/src/main/java/com/vaadin/spring/annotation/ViewContainer.java
@@ -1,0 +1,33 @@
+package com.vaadin.spring.annotation;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import org.springframework.context.annotation.Scope;
+
+import com.vaadin.navigator.ViewDisplay;
+import com.vaadin.spring.internal.UIScopeImpl;
+import com.vaadin.ui.ComponentContainer;
+import com.vaadin.ui.SingleComponentContainer;
+
+/**
+ * Stereotype annotation for a bean (implementing either {@link ViewDisplay},
+ * {@link SingleComponentContainer} or {@link ComponentContainer}) that should
+ * act as a view container for Vaadin Navigator.
+ *
+ * There should only be one bean annotated as the view container in the scope of
+ * a UI. If a view container bean implements multiple interfaces, it is
+ * primarily treated as a {@link ViewDisplay} if possible.
+ *
+ * @author Vaadin Ltd
+ */
+@Scope(UIScopeImpl.VAADIN_UI_SCOPE_NAME)
+@Retention(RUNTIME)
+@Target(TYPE)
+@Documented
+public @interface ViewContainer {
+}

--- a/vaadin-spring/src/main/java/com/vaadin/spring/navigator/SpringNavigator.java
+++ b/vaadin-spring/src/main/java/com/vaadin/spring/navigator/SpringNavigator.java
@@ -1,0 +1,44 @@
+package com.vaadin.spring.navigator;
+
+import org.springframework.beans.factory.annotation.Autowired;
+
+import com.vaadin.navigator.NavigationStateManager;
+import com.vaadin.navigator.Navigator;
+import com.vaadin.navigator.ViewDisplay;
+import com.vaadin.spring.annotation.UIScope;
+import com.vaadin.ui.ComponentContainer;
+import com.vaadin.ui.SingleComponentContainer;
+import com.vaadin.ui.UI;
+
+/**
+ * A Navigator that automatically uses {@link SpringViewProvider} and allows
+ * late initialization.
+ *
+ * @author Vaadin Ltd
+ */
+@UIScope
+public class SpringNavigator extends Navigator {
+
+    @Autowired
+    private SpringViewProvider viewProvider;
+
+    public void init(UI ui, ComponentContainer container) {
+        init(ui, new ComponentContainerViewDisplay(container));
+    }
+
+    public void init(UI ui, SingleComponentContainer container) {
+        init(ui, new SingleComponentContainerViewDisplay(container));
+    }
+
+    public void init(UI ui, ViewDisplay display) {
+        init(ui, new UriFragmentManager(ui.getPage()), display);
+    }
+
+    @Override
+    protected void init(UI ui, NavigationStateManager stateManager,
+            ViewDisplay display) {
+        super.init(ui, stateManager, display);
+        addProvider(viewProvider);
+    }
+
+}

--- a/vaadin-spring/src/main/java/com/vaadin/spring/navigator/SpringNavigator.java
+++ b/vaadin-spring/src/main/java/com/vaadin/spring/navigator/SpringNavigator.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2015 The original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.vaadin.spring.navigator;
 
 import org.springframework.beans.factory.annotation.Autowired;

--- a/vaadin-spring/src/main/java/com/vaadin/spring/navigator/SpringNavigator.java
+++ b/vaadin-spring/src/main/java/com/vaadin/spring/navigator/SpringNavigator.java
@@ -37,18 +37,78 @@ public class SpringNavigator extends Navigator {
     @Autowired
     private SpringViewProvider viewProvider;
 
+    /**
+     * Initializes an injected navigator and registers
+     * {@link SpringViewProvider} for it.
+     * <p>
+     * The default navigation state manager (based on URI fragments) is used.
+     * <p>
+     * Navigation is automatically initiated after {@code UI.init()} if a
+     * navigator was created. If at a later point changes are made to the
+     * navigator, {@code navigator.navigateTo(navigator.getState())} may need to
+     * be explicitly called to ensure the current view matches the navigation
+     * state.
+     *
+     * @param ui
+     *            The UI to which this Navigator is attached.
+     * @param container
+     *            The component container used to display the views handled by
+     *            this navigator
+     */
     public void init(UI ui, ComponentContainer container) {
         init(ui, new ComponentContainerViewDisplay(container));
     }
 
+    /**
+     * Initializes an injected navigator and registers
+     * {@link SpringViewProvider} for it.
+     * <p>
+     * The default navigation state manager (based on URI fragments) is used.
+     * <p>
+     * Navigation is automatically initiated after {@code UI.init()} if a
+     * navigator was created. If at a later point changes are made to the
+     * navigator, {@code navigator.navigateTo(navigator.getState())} may need to
+     * be explicitly called to ensure the current view matches the navigation
+     * state.
+     *
+     * @param ui
+     *            The UI to which this Navigator is attached.
+     * @param container
+     *            The single component container used to display the views
+     *            handled by this navigator
+     */
     public void init(UI ui, SingleComponentContainer container) {
         init(ui, new SingleComponentContainerViewDisplay(container));
     }
 
+    /**
+     * Initializes an injected navigator and registers
+     * {@link SpringViewProvider} for it.
+     * <p>
+     * The default navigation state manager (based on URI fragments) is used.
+     * <p>
+     * Navigation is automatically initiated after {@code UI.init()} if a
+     * navigator was created. If at a later point changes are made to the
+     * navigator, {@code navigator.navigateTo(navigator.getState())} may need to
+     * be explicitly called to ensure the current view matches the navigation
+     * state.
+     *
+     * @param ui
+     *            The UI to which this Navigator is attached.
+     * @param display
+     *            The ViewDisplay used to display the views handled by this
+     *            navigator
+     */
     public void init(UI ui, ViewDisplay display) {
         init(ui, new UriFragmentManager(ui.getPage()), display);
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * The {@link SpringViewProvider} bean from the context is automatically
+     * registered for the navigator.
+     */
     @Override
     protected void init(UI ui, NavigationStateManager stateManager,
             ViewDisplay display) {

--- a/vaadin-spring/src/main/java/com/vaadin/spring/server/SpringUIProvider.java
+++ b/vaadin-spring/src/main/java/com/vaadin/spring/server/SpringUIProvider.java
@@ -22,13 +22,18 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.web.context.WebApplicationContext;
 
+import com.vaadin.navigator.ViewDisplay;
 import com.vaadin.server.UIClassSelectionEvent;
 import com.vaadin.server.UICreateEvent;
 import com.vaadin.server.UIProvider;
 import com.vaadin.server.VaadinRequest;
 import com.vaadin.server.VaadinSession;
 import com.vaadin.spring.annotation.SpringUI;
+import com.vaadin.spring.annotation.ViewContainer;
 import com.vaadin.spring.internal.UIID;
+import com.vaadin.spring.navigator.SpringNavigator;
+import com.vaadin.ui.ComponentContainer;
+import com.vaadin.ui.SingleComponentContainer;
 import com.vaadin.ui.UI;
 import com.vaadin.util.CurrentInstance;
 
@@ -49,7 +54,8 @@ public class SpringUIProvider extends UIProvider {
     private final VaadinSession vaadinSession;
 
     /**
-     * Temporary cache for webApplicationContext, cleared if the session is serialized.
+     * Temporary cache for webApplicationContext, cleared if the session is
+     * serialized.
      */
     private transient WebApplicationContext webApplicationContext = null;
     private final Map<String, Class<? extends UI>> pathToUIMap = new ConcurrentHashMap<String, Class<? extends UI>>();
@@ -76,7 +82,8 @@ public class SpringUIProvider extends UIProvider {
         for (String uiBeanName : uiBeanNames) {
             Class<?> beanType = getWebApplicationContext().getType(uiBeanName);
             if (UI.class.isAssignableFrom(beanType)) {
-                logger.info("Found Vaadin UI [{}]", beanType.getCanonicalName());
+                logger.info("Found Vaadin UI [{}]",
+                        beanType.getCanonicalName());
                 final String path;
                 String tempPath = deriveMappingForUI(uiBeanName);
                 if (tempPath.length() > 0 && !tempPath.startsWith("/")) {
@@ -109,16 +116,16 @@ public class SpringUIProvider extends UIProvider {
      * @return path to map the UI to
      */
     protected String deriveMappingForUI(String uiBeanName) {
-        SpringUI annotation = getWebApplicationContext().findAnnotationOnBean(
-                uiBeanName, SpringUI.class);
+        SpringUI annotation = getWebApplicationContext()
+                .findAnnotationOnBean(uiBeanName, SpringUI.class);
         return annotation.path();
     }
 
     @Override
     public Class<? extends UI> getUIClass(
             UIClassSelectionEvent uiClassSelectionEvent) {
-        final String path = extractUIPathFromRequest(uiClassSelectionEvent
-                .getRequest());
+        final String path = extractUIPathFromRequest(
+                uiClassSelectionEvent.getRequest());
         if (pathToUIMap.containsKey(path)) {
             return pathToUIMap.get(path);
         }
@@ -152,8 +159,8 @@ public class SpringUIProvider extends UIProvider {
 
     protected WebApplicationContext getWebApplicationContext() {
         if (webApplicationContext == null) {
-            webApplicationContext = ((SpringVaadinServletService) vaadinSession.getService())
-                    .getWebApplicationContext();
+            webApplicationContext = ((SpringVaadinServletService) vaadinSession
+                    .getService()).getWebApplicationContext();
         }
 
         return webApplicationContext;
@@ -181,10 +188,73 @@ public class SpringUIProvider extends UIProvider {
             logger.debug(
                     "Creating a new UI bean of class [{}] with identifier [{}]",
                     event.getUIClass().getCanonicalName(), identifier);
-            return getWebApplicationContext().getBean(event.getUIClass());
+            UI ui = getWebApplicationContext().getBean(event.getUIClass());
+            configureNavigator(ui);
+            return ui;
         } finally {
             CurrentInstance.set(key, null);
         }
+    }
+
+    protected void configureNavigator(UI ui) {
+        Object viewContainer = findViewContainer(ui);
+        SpringNavigator navigator = getNavigator();
+        if (navigator == null) {
+            return;
+        }
+
+        if (viewContainer instanceof ViewDisplay) {
+            navigator.init(ui, (ViewDisplay) viewContainer);
+        } else if (viewContainer instanceof SingleComponentContainer) {
+            navigator.init(ui, (SingleComponentContainer) viewContainer);
+        } else if (viewContainer instanceof ComponentContainer) {
+            navigator.init(ui, (ComponentContainer) viewContainer);
+        } else {
+            logger.error(
+                    "View container does not implement ViewDisplay/SingleComponentContainer/ComponentContainer: "
+                            + viewContainer);
+            throw new IllegalStateException(
+                    "View container does not implement ViewDisplay/SingleComponentContainer/ComponentContainer: "
+                            + viewContainer);
+        }
+    }
+
+    /**
+     * Returns the configured navigator bean or null if no bean defined.
+     *
+     * @return bean extending {@link SpringNavigator} or null if none defined
+     */
+    protected SpringNavigator getNavigator() {
+        String[] beanNames = getWebApplicationContext()
+                .getBeanNamesForType(SpringNavigator.class);
+        if (beanNames.length > 0) {
+            if (beanNames.length > 1) {
+                logger.warn("Multiple navigator beans defined");
+            }
+            return (SpringNavigator) getWebApplicationContext()
+                    .getBean(beanNames[0]);
+        } else {
+            logger.info("No navigator bean defined");
+            return null;
+        }
+    }
+
+    protected Object findViewContainer(UI ui) {
+        final String[] viewContainerBeanNames = getWebApplicationContext()
+                .getBeanNamesForAnnotation(ViewContainer.class);
+        if (viewContainerBeanNames.length == 0) {
+            logger.debug("No view container defined for the UI " + ui.getId());
+        }
+        if (viewContainerBeanNames.length > 1) {
+            logger.error("Multiple view containers defined for the UI "
+                    + ui.getId());
+            throw new IllegalStateException(
+                    "A UI must only have one view containers, but multiple view containers are defined for UI "
+                            + ui.getId());
+        }
+        Object viewContainer = getWebApplicationContext()
+                .getBean(viewContainerBeanNames[0]);
+        return viewContainer;
     }
 
 }

--- a/vaadin-spring/src/test/java/com/vaadin/spring/server/AbstractSpringUIProviderTest.java
+++ b/vaadin-spring/src/test/java/com/vaadin/spring/server/AbstractSpringUIProviderTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2015 The original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.vaadin.spring.server;
 
 import java.util.Properties;

--- a/vaadin-spring/src/test/java/com/vaadin/spring/server/AbstractSpringUIProviderTest.java
+++ b/vaadin-spring/src/test/java/com/vaadin/spring/server/AbstractSpringUIProviderTest.java
@@ -1,0 +1,135 @@
+package com.vaadin.spring.server;
+
+import java.util.Properties;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockServletConfig;
+import org.springframework.mock.web.MockServletContext;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.web.context.WebApplicationContext;
+
+import com.vaadin.server.DefaultDeploymentConfiguration;
+import com.vaadin.server.ServiceException;
+import com.vaadin.server.UICreateEvent;
+import com.vaadin.server.VaadinRequest;
+import com.vaadin.server.VaadinServlet;
+import com.vaadin.server.VaadinSession;
+import com.vaadin.spring.VaadinConfiguration;
+import com.vaadin.ui.UI;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+// make sure the context is cleaned
+@DirtiesContext
+public abstract class AbstractSpringUIProviderTest {
+
+    @Configuration
+    protected static class Config extends VaadinConfiguration {
+        @Bean
+        public VaadinServlet vaadinServlet() {
+            return new SpringVaadinServlet();
+        }
+    }
+
+    private final class MySpringVaadinServletService
+            extends SpringVaadinServletService {
+        private MySpringVaadinServletService(VaadinServlet servlet)
+                throws ServiceException {
+            super(servlet, new DefaultDeploymentConfiguration(
+                    MySpringVaadinServletService.class, new Properties()), "");
+            init();
+        }
+
+        @Override
+        public VaadinSession createVaadinSession(VaadinRequest request)
+                throws com.vaadin.server.ServiceException {
+            return super.createVaadinSession(request);
+        }
+
+    }
+
+    protected static final int TEST_UIID = 123;
+
+    @Autowired
+    private WebApplicationContext applicationContext;
+
+    @Autowired
+    private MockServletContext servletContext;
+
+    @Autowired
+    private MockHttpServletRequest request;
+
+    @Autowired
+    private SpringVaadinServlet servlet;
+
+    private MySpringVaadinServletService service;
+    private SpringVaadinServletRequest vaadinServletRequest;
+    private VaadinSession vaadinSession;
+    private SpringUIProvider uiProvider;
+
+    @Before
+    public void setup() throws Exception {
+        // need to circumvent a lot of normal mechanisms as many relevant
+        // methods are private
+        // TODO very ugly - can this be simplified?
+        servlet.init(new MockServletConfig(servletContext));
+        setService(new MySpringVaadinServletService(servlet));
+        setVaadinServletRequest(
+                new SpringVaadinServletRequest(request, getService(), true));
+        setVaadinSession(
+                getService().createVaadinSession(getVaadinServletRequest()));
+        VaadinSession.setCurrent(vaadinSession);
+
+        uiProvider = new SpringUIProvider(getVaadinSession());
+    }
+
+    @After
+    public void tearDown() {
+        VaadinSession.setCurrent(null);
+    }
+
+    protected SpringUIProvider getUiProvider() {
+        return uiProvider;
+    }
+
+    protected UICreateEvent buildUiCreateEvent(Class<? extends UI> uiClass) {
+        return new UICreateEvent(getVaadinServletRequest(), uiClass, TEST_UIID);
+    }
+
+    @SuppressWarnings("unchecked")
+    protected <T extends UI> T createUi(Class<T> uiClass) {
+        return (T) getUiProvider().createInstance(buildUiCreateEvent(uiClass));
+    }
+
+    public MySpringVaadinServletService getService() {
+        return service;
+    }
+
+    private void setService(MySpringVaadinServletService service) {
+        this.service = service;
+    }
+
+    public SpringVaadinServletRequest getVaadinServletRequest() {
+        return vaadinServletRequest;
+    }
+
+    private void setVaadinServletRequest(
+            SpringVaadinServletRequest vaadinServletRequest) {
+        this.vaadinServletRequest = vaadinServletRequest;
+    }
+
+    public VaadinSession getVaadinSession() {
+        return vaadinSession;
+    }
+
+    private void setVaadinSession(VaadinSession vaadinSession) {
+        this.vaadinSession = vaadinSession;
+    }
+
+}

--- a/vaadin-spring/src/test/java/com/vaadin/spring/server/SpringUIProviderTestWithPanelAsViewContainer.java
+++ b/vaadin-spring/src/test/java/com/vaadin/spring/server/SpringUIProviderTestWithPanelAsViewContainer.java
@@ -1,0 +1,77 @@
+package com.vaadin.spring.server;
+
+import org.junit.Test;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.stereotype.Component;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.util.Assert;
+
+import com.vaadin.navigator.Navigator.SingleComponentContainerViewDisplay;
+import com.vaadin.server.VaadinRequest;
+import com.vaadin.spring.annotation.SpringUI;
+import com.vaadin.spring.annotation.UIScope;
+import com.vaadin.spring.annotation.ViewContainer;
+import com.vaadin.spring.navigator.SpringNavigator;
+import com.vaadin.ui.Panel;
+import com.vaadin.ui.UI;
+
+/**
+ * Test for normal (full) use cases of SpringUIProvider with automatic
+ * navigation configuration on the view.
+ */
+@ContextConfiguration
+@WebAppConfiguration
+public class SpringUIProviderTestWithPanelAsViewContainer
+        extends AbstractSpringUIProviderTest {
+
+    @SpringUI
+    private static class TestUI extends UI {
+        @Override
+        protected void init(VaadinRequest request) {
+        }
+    }
+
+    @UIScope
+    @Component
+    @ViewContainer
+    private static class MyPanel extends Panel {
+    }
+
+    @Configuration
+    static class Config extends AbstractSpringUIProviderTest.Config {
+        @Bean
+        public SpringNavigator navigator() {
+            return new SpringNavigator();
+        }
+
+        @Bean
+        public MyPanel myPanel() {
+            return new MyPanel();
+        }
+
+        // this gets configured by the UI provider
+        @Bean
+        public TestUI ui() {
+            return new TestUI();
+        }
+    }
+
+    @Test
+    public void testConfigureNavigator() {
+        TestUI ui = createUi(TestUI.class);
+        Assert.isInstanceOf(SingleComponentContainerViewDisplay.class,
+                ui.getNavigator().getDisplay(),
+                "Navigator is not configured for SingleComponentContainerViewDisplay");
+    }
+
+    @Test
+    public void testFindViewContainer() throws Exception {
+        TestUI ui = createUi(TestUI.class);
+        Assert.isInstanceOf(MyPanel.class,
+                getUiProvider().findViewContainer(ui),
+                "View container is not a Panel");
+    }
+
+}

--- a/vaadin-spring/src/test/java/com/vaadin/spring/server/SpringUIProviderTestWithPanelAsViewContainer.java
+++ b/vaadin-spring/src/test/java/com/vaadin/spring/server/SpringUIProviderTestWithPanelAsViewContainer.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2015 The original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.vaadin.spring.server;
 
 import org.junit.Test;

--- a/vaadin-spring/src/test/java/com/vaadin/spring/server/SpringUIProviderTestWithUiImplementingViewDisplayAsViewContainer.java
+++ b/vaadin-spring/src/test/java/com/vaadin/spring/server/SpringUIProviderTestWithUiImplementingViewDisplayAsViewContainer.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2015 The original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.vaadin.spring.server;
 
 import org.junit.Test;

--- a/vaadin-spring/src/test/java/com/vaadin/spring/server/SpringUIProviderTestWithUiImplementingViewDisplayAsViewContainer.java
+++ b/vaadin-spring/src/test/java/com/vaadin/spring/server/SpringUIProviderTestWithUiImplementingViewDisplayAsViewContainer.java
@@ -1,0 +1,73 @@
+package com.vaadin.spring.server;
+
+import org.junit.Test;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.util.Assert;
+
+import com.vaadin.navigator.View;
+import com.vaadin.navigator.ViewDisplay;
+import com.vaadin.server.VaadinRequest;
+import com.vaadin.spring.annotation.SpringUI;
+import com.vaadin.spring.annotation.ViewContainer;
+import com.vaadin.spring.navigator.SpringNavigator;
+import com.vaadin.ui.UI;
+
+/**
+ * Test for normal (full) use cases of SpringUIProvider with automatic
+ * navigation configuration on the view.
+ */
+@ContextConfiguration
+@WebAppConfiguration
+public class SpringUIProviderTestWithUiImplementingViewDisplayAsViewContainer
+        extends AbstractSpringUIProviderTest {
+
+    @SpringUI
+    @ViewContainer
+    private static class TestUI extends UI implements ViewDisplay {
+        @Override
+        protected void init(VaadinRequest request) {
+        }
+
+        @Override
+        public void showView(View view) {
+        }
+    }
+
+    @Configuration
+    static class Config extends AbstractSpringUIProviderTest.Config {
+        @Bean
+        public SpringNavigator navigator() {
+            return new SpringNavigator();
+        }
+
+        // this gets configured by the UI provider
+        @Bean
+        public TestUI ui() {
+            return new TestUI();
+        }
+    }
+
+    @Test
+    public void testGetNavigator() throws Exception {
+        Assert.notNull(getUiProvider().getNavigator(),
+                "Navigator not available in SpringUIProvider");
+    }
+
+    @Test
+    public void testConfigureNavigator() {
+        TestUI ui = createUi(TestUI.class);
+        Assert.isTrue(ui.getNavigator().getDisplay() instanceof TestUI,
+                "Navigator is not configured for a custom ViewDisplay");
+    }
+
+    @Test
+    public void testFindViewContainer() throws Exception {
+        TestUI ui = createUi(TestUI.class);
+        Assert.isInstanceOf(TestUI.class, getUiProvider().findViewContainer(ui),
+                "View container is not a TestUI");
+    }
+
+}

--- a/vaadin-spring/src/test/java/com/vaadin/spring/server/SpringUIProviderTestWithoutNavigatorBean.java
+++ b/vaadin-spring/src/test/java/com/vaadin/spring/server/SpringUIProviderTestWithoutNavigatorBean.java
@@ -1,0 +1,49 @@
+package com.vaadin.spring.server;
+
+import org.junit.Test;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.util.Assert;
+
+import com.vaadin.server.VaadinRequest;
+import com.vaadin.spring.annotation.SpringUI;
+import com.vaadin.spring.annotation.ViewContainer;
+import com.vaadin.ui.UI;
+
+@ContextConfiguration
+@WebAppConfiguration
+public class SpringUIProviderTestWithoutNavigatorBean
+        extends AbstractSpringUIProviderTest {
+
+    @SpringUI
+    @ViewContainer
+    private static class TestUI extends UI {
+        @Override
+        protected void init(VaadinRequest request) {
+        }
+    }
+
+    @Configuration
+    static class Config extends AbstractSpringUIProviderTest.Config {
+        // this gets configured by the UI provider
+        @Bean
+        public TestUI ui() {
+            return new TestUI();
+        }
+    }
+
+    @Test
+    public void testGetNavigator() throws Exception {
+        Assert.isNull(getUiProvider().getNavigator(),
+                "SpringUIProvider uses a navigator even though none was defined");
+    }
+
+    @Test
+    public void testConfigureNavigator() {
+        TestUI ui = createUi(TestUI.class);
+        Assert.isNull(ui.getNavigator(),
+                "Navigator should not be configured for UI when no navigator bean is available");
+    }
+}

--- a/vaadin-spring/src/test/java/com/vaadin/spring/server/SpringUIProviderTestWithoutNavigatorBean.java
+++ b/vaadin-spring/src/test/java/com/vaadin/spring/server/SpringUIProviderTestWithoutNavigatorBean.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2015 The original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.vaadin.spring.server;
 
 import org.junit.Test;

--- a/vaadin-spring/src/test/java/com/vaadin/spring/server/SpringUIProviderTestWithoutViewContainer.java
+++ b/vaadin-spring/src/test/java/com/vaadin/spring/server/SpringUIProviderTestWithoutViewContainer.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2015 The original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.vaadin.spring.server;
+
+import org.junit.Test;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.util.Assert;
+
+import com.vaadin.server.VaadinRequest;
+import com.vaadin.spring.annotation.SpringUI;
+import com.vaadin.spring.navigator.SpringNavigator;
+import com.vaadin.ui.UI;
+
+/**
+ * Test for normal (full) use cases of SpringUIProvider with automatic
+ * navigation configuration on the view.
+ */
+@ContextConfiguration
+@WebAppConfiguration
+public class SpringUIProviderTestWithoutViewContainer
+        extends AbstractSpringUIProviderTest {
+
+    @SpringUI
+    private static class TestUI extends UI {
+        @Override
+        protected void init(VaadinRequest request) {
+        }
+    }
+
+    @Configuration
+    static class Config extends AbstractSpringUIProviderTest.Config {
+        @Bean
+        public SpringNavigator navigator() {
+            return new SpringNavigator();
+        }
+
+        // this gets configured by the UI provider
+        @Bean
+        public TestUI ui() {
+            return new TestUI();
+        }
+    }
+
+    @Test
+    public void testConfigureNavigator() {
+        TestUI ui = createUi(TestUI.class);
+        Assert.isNull(ui.getNavigator(),
+                "Navigator is configured even though there is no ViewContainer");
+    }
+
+    @Test
+    public void testFindViewContainer() throws Exception {
+        TestUI ui = createUi(TestUI.class);
+        Assert.isNull(getUiProvider().findViewContainer(ui),
+                "View container is not a Panel");
+    }
+
+}


### PR DESCRIPTION
Add a ViewContainer annotation and automatic configuration of navigation based on it.

This version does not automatically create SpringNavigator beans.

Closes #86
Closes #88

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/spring/98)
<!-- Reviewable:end -->
