### PR TITLE
Automatically create SpringNavigator bean with Spring Boot

### DIFF
--- a/vaadin-spring-boot/pom.xml
+++ b/vaadin-spring-boot/pom.xml
@@ -55,6 +55,20 @@
             <version>3.0.1</version>
             <scope>provided</scope>
         </dependency>
+
+        <!-- Test dependencies -->
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-test</artifactId>
+            <version>${spring.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.11</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     
     <build>

--- a/vaadin-spring-boot/pom.xml
+++ b/vaadin-spring-boot/pom.xml
@@ -58,6 +58,13 @@
 
         <!-- Test dependencies -->
         <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-spring</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-test</artifactId>
             <version>${spring.version}</version>

--- a/vaadin-spring-boot/src/main/java/com/vaadin/spring/boot/VaadinAutoConfiguration.java
+++ b/vaadin-spring-boot/src/main/java/com/vaadin/spring/boot/VaadinAutoConfiguration.java
@@ -19,9 +19,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Configuration;
 
 import com.vaadin.spring.annotation.EnableVaadin;
+import com.vaadin.spring.annotation.EnableVaadinNavigation;
 import com.vaadin.spring.annotation.SpringUI;
 import com.vaadin.spring.boot.annotation.EnableVaadinServlet;
 
@@ -41,6 +43,17 @@ public class VaadinAutoConfiguration {
     @Configuration
     @EnableVaadin
     static class EnableVaadinConfiguration implements InitializingBean {
+        @Override
+        public void afterPropertiesSet() throws Exception {
+            logger.debug("{} initialized", getClass().getName());
+        }
+    }
+
+    @Configuration
+    @EnableVaadinNavigation
+    @ConditionalOnMissingBean(type = "com.vaadin.spring.navigator.SpringNavigator")
+    static class EnableVaadinNavigatorConfiguration
+            implements InitializingBean {
         @Override
         public void afterPropertiesSet() throws Exception {
             logger.debug("{} initialized", getClass().getName());

--- a/vaadin-spring-boot/src/test/java/com/vaadin/spring/boot/VaadinAutoConfigurationTest.java
+++ b/vaadin-spring-boot/src/test/java/com/vaadin/spring/boot/VaadinAutoConfigurationTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2015 The original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.vaadin.spring.boot;
 
 import org.junit.Test;

--- a/vaadin-spring-boot/src/test/java/com/vaadin/spring/boot/VaadinAutoConfigurationTest.java
+++ b/vaadin-spring-boot/src/test/java/com/vaadin/spring/boot/VaadinAutoConfigurationTest.java
@@ -35,6 +35,7 @@ import com.vaadin.spring.server.SpringVaadinServlet;
 @WebAppConfiguration
 // make sure the context is cleaned
 @DirtiesContext
+// TODO this test should have an active UI scope
 public class VaadinAutoConfigurationTest {
 
     @Autowired

--- a/vaadin-spring-boot/src/test/java/com/vaadin/spring/boot/VaadinAutoConfigurationTest.java
+++ b/vaadin-spring-boot/src/test/java/com/vaadin/spring/boot/VaadinAutoConfigurationTest.java
@@ -1,0 +1,45 @@
+package com.vaadin.spring.boot;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.util.Assert;
+import org.springframework.web.context.WebApplicationContext;
+
+import com.vaadin.spring.navigator.SpringNavigator;
+import com.vaadin.spring.server.SpringVaadinServlet;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration
+@WebAppConfiguration
+// make sure the context is cleaned
+@DirtiesContext
+public class VaadinAutoConfigurationTest {
+
+    @Autowired
+    private WebApplicationContext applicationContext;
+
+    @Configuration
+    protected static class Config extends VaadinAutoConfiguration {
+    }
+
+    @Test
+    public void testVaadinServletDefined() {
+        Assert.isInstanceOf(SpringVaadinServlet.class,
+                applicationContext.getBean("vaadinServlet"),
+                "Vaadin servlet is not autoconfigured");
+    }
+
+    @Test
+    public void testNavigatorDefined() {
+        Assert.isInstanceOf(SpringNavigator.class,
+                applicationContext.getBean(SpringNavigator.class),
+                "Vaadin Navigator is not autoconfigured");
+    }
+
+}

--- a/vaadin-spring-boot/src/test/java/com/vaadin/spring/boot/VaadinAutoConfigurationTest.java
+++ b/vaadin-spring-boot/src/test/java/com/vaadin/spring/boot/VaadinAutoConfigurationTest.java
@@ -28,6 +28,7 @@ import org.springframework.util.Assert;
 import org.springframework.web.context.WebApplicationContext;
 
 import com.vaadin.spring.navigator.SpringNavigator;
+import com.vaadin.spring.server.AbstractSpringUIProviderTest;
 import com.vaadin.spring.server.SpringVaadinServlet;
 
 @RunWith(SpringJUnit4ClassRunner.class)
@@ -35,8 +36,7 @@ import com.vaadin.spring.server.SpringVaadinServlet;
 @WebAppConfiguration
 // make sure the context is cleaned
 @DirtiesContext
-// TODO this test should have an active UI scope
-public class VaadinAutoConfigurationTest {
+public class VaadinAutoConfigurationTest extends AbstractSpringUIProviderTest {
 
     @Autowired
     private WebApplicationContext applicationContext;

--- a/vaadin-spring-boot/src/test/java/com/vaadin/spring/boot/VaadinAutoConfigurationTest.java
+++ b/vaadin-spring-boot/src/test/java/com/vaadin/spring/boot/VaadinAutoConfigurationTest.java
@@ -18,6 +18,7 @@ package com.vaadin.spring.boot;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
@@ -40,7 +41,8 @@ public class VaadinAutoConfigurationTest {
     private WebApplicationContext applicationContext;
 
     @Configuration
-    protected static class Config extends VaadinAutoConfiguration {
+    @EnableAutoConfiguration
+    protected static class Config {
     }
 
     @Test

--- a/vaadin-spring-boot/src/test/java/com/vaadin/spring/boot/VaadinAutoConfigurationWithCustomNavigatorTest.java
+++ b/vaadin-spring-boot/src/test/java/com/vaadin/spring/boot/VaadinAutoConfigurationWithCustomNavigatorTest.java
@@ -1,0 +1,45 @@
+package com.vaadin.spring.boot;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.util.Assert;
+import org.springframework.web.context.WebApplicationContext;
+
+import com.vaadin.spring.navigator.SpringNavigator;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration
+@WebAppConfiguration
+// make sure the context is cleaned
+@DirtiesContext
+public class VaadinAutoConfigurationWithCustomNavigatorTest {
+
+    @Autowired
+    private WebApplicationContext applicationContext;
+
+    private static class MyNavigator extends SpringNavigator {
+    }
+
+    @Configuration
+    protected static class Config extends VaadinAutoConfiguration {
+        @Bean
+        public MyNavigator myNavigator() {
+            return new MyNavigator();
+        }
+    }
+
+    @Test
+    public void testNavigatorCustomized() {
+        Assert.isInstanceOf(MyNavigator.class,
+                applicationContext.getBean(SpringNavigator.class),
+                "Vaadin Navigator is not correctly overridden");
+    }
+
+}

--- a/vaadin-spring-boot/src/test/java/com/vaadin/spring/boot/VaadinAutoConfigurationWithCustomNavigatorTest.java
+++ b/vaadin-spring-boot/src/test/java/com/vaadin/spring/boot/VaadinAutoConfigurationWithCustomNavigatorTest.java
@@ -29,14 +29,15 @@ import org.springframework.util.Assert;
 import org.springframework.web.context.WebApplicationContext;
 
 import com.vaadin.spring.navigator.SpringNavigator;
+import com.vaadin.spring.server.AbstractSpringUIProviderTest;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration
 @WebAppConfiguration
 // make sure the context is cleaned
 @DirtiesContext
-// TODO this test should have an active UI scope
-public class VaadinAutoConfigurationWithCustomNavigatorTest {
+public class VaadinAutoConfigurationWithCustomNavigatorTest
+        extends AbstractSpringUIProviderTest {
 
     @Autowired
     private WebApplicationContext applicationContext;

--- a/vaadin-spring-boot/src/test/java/com/vaadin/spring/boot/VaadinAutoConfigurationWithCustomNavigatorTest.java
+++ b/vaadin-spring-boot/src/test/java/com/vaadin/spring/boot/VaadinAutoConfigurationWithCustomNavigatorTest.java
@@ -18,6 +18,7 @@ package com.vaadin.spring.boot;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.test.annotation.DirtiesContext;
@@ -43,7 +44,10 @@ public class VaadinAutoConfigurationWithCustomNavigatorTest {
     }
 
     @Configuration
-    protected static class Config extends VaadinAutoConfiguration {
+    // using this rather than extending a configuration will let us override
+    // defaults
+    @EnableAutoConfiguration
+    protected static class Config {
         @Bean
         public MyNavigator myNavigator() {
             return new MyNavigator();

--- a/vaadin-spring-boot/src/test/java/com/vaadin/spring/boot/VaadinAutoConfigurationWithCustomNavigatorTest.java
+++ b/vaadin-spring-boot/src/test/java/com/vaadin/spring/boot/VaadinAutoConfigurationWithCustomNavigatorTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2015 The original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.vaadin.spring.boot;
 
 import org.junit.Test;

--- a/vaadin-spring-boot/src/test/java/com/vaadin/spring/boot/VaadinAutoConfigurationWithCustomNavigatorTest.java
+++ b/vaadin-spring-boot/src/test/java/com/vaadin/spring/boot/VaadinAutoConfigurationWithCustomNavigatorTest.java
@@ -35,6 +35,7 @@ import com.vaadin.spring.navigator.SpringNavigator;
 @WebAppConfiguration
 // make sure the context is cleaned
 @DirtiesContext
+// TODO this test should have an active UI scope
 public class VaadinAutoConfigurationWithCustomNavigatorTest {
 
     @Autowired

--- a/vaadin-spring/pom.xml
+++ b/vaadin-spring/pom.xml
@@ -90,6 +90,13 @@
                         <include>com/**</include>
                     </includes>
                 </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>    

--- a/vaadin-spring/src/main/java/com/vaadin/spring/VaadinNavigatorConfiguration.java
+++ b/vaadin-spring/src/main/java/com/vaadin/spring/VaadinNavigatorConfiguration.java
@@ -19,6 +19,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import com.vaadin.spring.annotation.EnableVaadinNavigation;
+import com.vaadin.spring.annotation.UIScope;
 import com.vaadin.spring.navigator.SpringNavigator;
 
 /**
@@ -34,6 +35,7 @@ import com.vaadin.spring.navigator.SpringNavigator;
 public class VaadinNavigatorConfiguration {
 
     @Bean
+    @UIScope
     static SpringNavigator vaadinNavigator() {
         return new SpringNavigator();
     }

--- a/vaadin-spring/src/main/java/com/vaadin/spring/VaadinNavigatorConfiguration.java
+++ b/vaadin-spring/src/main/java/com/vaadin/spring/VaadinNavigatorConfiguration.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2015 The original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.vaadin.spring;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.vaadin.spring.annotation.EnableVaadinNavigation;
+import com.vaadin.spring.navigator.SpringNavigator;
+
+/**
+ * Spring configuration for automatically configuring a SpringNavigator.
+ *
+ * Instead of using this class directly, it is recommended to add the
+ * {@link EnableVaadinNavigation} annotation to a configuration class to
+ * automatically import {@link VaadinNavigatorConfiguration}.
+ *
+ * @author Henri Sara (hesara@vaadin.com)
+ */
+@Configuration
+public class VaadinNavigatorConfiguration {
+
+    @Bean
+    static SpringNavigator vaadinNavigator() {
+        return new SpringNavigator();
+    }
+
+}

--- a/vaadin-spring/src/main/java/com/vaadin/spring/annotation/EnableVaadinNavigation.java
+++ b/vaadin-spring/src/main/java/com/vaadin/spring/annotation/EnableVaadinNavigation.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2015 The original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.vaadin.spring.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+import com.vaadin.spring.VaadinNavigatorConfiguration;
+
+/**
+ * Brings in the machinery to configure automatic navigation based on
+ * {@link ViewContainer} annotations. This annotation should be added on a
+ * {@link Configuration} class of the application to automatically import
+ * {@link VaadinNavigatorConfiguration}.
+ *
+ * @author Henri Sara (hesara@vaadin.com)
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Import(VaadinNavigatorConfiguration.class)
+public @interface EnableVaadinNavigation {
+}

--- a/vaadin-spring/src/main/java/com/vaadin/spring/server/SpringUIProvider.java
+++ b/vaadin-spring/src/main/java/com/vaadin/spring/server/SpringUIProvider.java
@@ -23,6 +23,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.beans.factory.NoUniqueBeanDefinitionException;
 import org.springframework.web.context.WebApplicationContext;
 
 import com.vaadin.navigator.ViewDisplay;
@@ -244,6 +245,8 @@ public class SpringUIProvider extends UIProvider {
     protected SpringNavigator getNavigator() {
         try {
             return getWebApplicationContext().getBean(SpringNavigator.class);
+        } catch (NoUniqueBeanDefinitionException e) {
+            throw e;
         } catch (NoSuchBeanDefinitionException e) {
             // While relying on exceptions here is not very nice, using
             // getBean(Class) takes scopes, qualifiers etc. into account

--- a/vaadin-spring/src/test/java/com/vaadin/spring/server/AbstractSpringUIProviderTest.java
+++ b/vaadin-spring/src/test/java/com/vaadin/spring/server/AbstractSpringUIProviderTest.java
@@ -15,34 +15,22 @@
  */
 package com.vaadin.spring.server;
 
-import java.util.Properties;
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReentrantLock;
+import javax.servlet.http.HttpServletRequest;
 
-import org.junit.After;
 import org.junit.Before;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.mock.web.MockHttpServletRequest;
-import org.springframework.mock.web.MockHttpSession;
-import org.springframework.mock.web.MockServletConfig;
-import org.springframework.mock.web.MockServletContext;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.context.WebApplicationContext;
 
-import com.vaadin.server.DefaultDeploymentConfiguration;
-import com.vaadin.server.DeploymentConfiguration;
-import com.vaadin.server.ServiceException;
 import com.vaadin.server.UICreateEvent;
-import com.vaadin.server.VaadinRequest;
-import com.vaadin.server.VaadinServlet;
-import com.vaadin.server.VaadinSession;
-import com.vaadin.server.WrappedSession;
+import com.vaadin.server.VaadinServletService;
 import com.vaadin.spring.annotation.EnableVaadin;
+import com.vaadin.spring.internal.UIScopeImpl;
+import com.vaadin.spring.test.util.SingletonBeanStoreRetrievalStrategy;
+import com.vaadin.spring.test.util.TestVaadinSession;
 import com.vaadin.ui.UI;
 
 @RunWith(SpringJUnit4ClassRunner.class)
@@ -50,73 +38,9 @@ import com.vaadin.ui.UI;
 @DirtiesContext
 public abstract class AbstractSpringUIProviderTest {
 
-    private static final class MyVaadinSession extends VaadinSession {
-
-        public MyVaadinSession(MySpringVaadinServletService service) {
-            super(service);
-        }
-
-        @Override
-        public boolean hasLock() {
-            return true;
-        }
-
-    }
-
-    // override methods to increase their visibility
-    private static final class MySpringVaadinServletService
-            extends SpringVaadinServletService {
-        private Lock sessionLock = new ReentrantLock();
-
-        private MySpringVaadinServletService(VaadinServlet servlet)
-                throws ServiceException {
-            super(servlet, new DefaultDeploymentConfiguration(
-                    MySpringVaadinServletService.class, new Properties()), "");
-            init();
-        }
-
-        @Override
-        public MyVaadinSession createVaadinSession(VaadinRequest request)
-                throws com.vaadin.server.ServiceException {
-            return new MyVaadinSession(this);
-        }
-
-        @Override
-        protected Lock getSessionLock(WrappedSession wrappedSession) {
-            return sessionLock;
-        }
-
-        @Override
-        public void lockSession(WrappedSession wrappedSession) {
-            super.lockSession(wrappedSession);
-        }
-    }
-
-    private static final class MyVaadinServlet extends SpringVaadinServlet {
-        @Override
-        public MySpringVaadinServletService getService() {
-            return (MySpringVaadinServletService) super.getService();
-        }
-
-        @Override
-        protected MySpringVaadinServletService createServletService(
-                DeploymentConfiguration deploymentConfiguration)
-                throws ServiceException {
-            // this is needed when using a custom service URL
-            MySpringVaadinServletService service = new MySpringVaadinServletService(
-                    this);
-            service.init();
-            return service;
-        }
-    }
-
     @Configuration
     @EnableVaadin
     protected static class Config {
-        @Bean
-        public MyVaadinServlet vaadinServlet() {
-            return new MyVaadinServlet();
-        }
     }
 
     protected static final int TEST_UIID = 123;
@@ -125,49 +49,18 @@ public abstract class AbstractSpringUIProviderTest {
     private WebApplicationContext applicationContext;
 
     @Autowired
-    private MockServletContext servletContext;
+    private HttpServletRequest request;
 
-    @Autowired
-    private MockHttpServletRequest request;
-
-    @Autowired
-    private MockHttpSession session;
-
-    @Autowired
-    private MyVaadinServlet servlet;
-
-    private MySpringVaadinServletService service;
-    private SpringVaadinServletRequest vaadinServletRequest;
-    private MyVaadinSession vaadinSession;
+    private TestVaadinSession vaadinSession;
     private SpringUIProvider uiProvider;
 
     @Before
     public void setup() throws Exception {
-        // need to circumvent a lot of normal mechanisms as many relevant
-        // methods are private
-        // TODO very ugly - can this be simplified?
-        servlet.init(new MockServletConfig(servletContext));
-        service = servlet.getService();
-        vaadinServletRequest = new SpringVaadinServletRequest(request, service,
-                true);
-        vaadinSession = service.createVaadinSession(vaadinServletRequest);
-        VaadinSession.setCurrent(vaadinSession);
-        // make sure the lock etc. exist in the session
-        ReflectionTestUtils.setField(vaadinSession, "service", service);
-        ReflectionTestUtils.setField(vaadinSession, "session",
-                vaadinServletRequest.getWrappedSession());
-        ReflectionTestUtils.setField(vaadinSession, "lock",
-                service.sessionLock);
+        UIScopeImpl.setBeanStoreRetrievalStrategy(
+                new SingletonBeanStoreRetrievalStrategy());
 
-        service.lockSession(vaadinSession.getSession());
-
-        uiProvider = new SpringUIProvider(getVaadinSession());
-    }
-
-    @After
-    public void tearDown() {
-        vaadinSession.unlock();
-        VaadinSession.setCurrent(null);
+        vaadinSession = new TestVaadinSession(applicationContext);
+        uiProvider = new SpringUIProvider(vaadinSession);
     }
 
     protected SpringUIProvider getUiProvider() {
@@ -175,24 +68,14 @@ public abstract class AbstractSpringUIProviderTest {
     }
 
     protected UICreateEvent buildUiCreateEvent(Class<? extends UI> uiClass) {
-        return new UICreateEvent(getVaadinServletRequest(), uiClass, TEST_UIID);
+        return new UICreateEvent(new SpringVaadinServletRequest(request,
+                (VaadinServletService) vaadinSession.getService(), false),
+                uiClass, TEST_UIID);
     }
 
     @SuppressWarnings("unchecked")
     protected <T extends UI> T createUi(Class<T> uiClass) {
         return (T) getUiProvider().createInstance(buildUiCreateEvent(uiClass));
-    }
-
-    public MySpringVaadinServletService getService() {
-        return service;
-    }
-
-    public SpringVaadinServletRequest getVaadinServletRequest() {
-        return vaadinServletRequest;
-    }
-
-    public VaadinSession getVaadinSession() {
-        return vaadinSession;
     }
 
 }

--- a/vaadin-spring/src/test/java/com/vaadin/spring/server/SpringUIProviderTestWithCustomAndDefaultNavigatorBean.java
+++ b/vaadin-spring/src/test/java/com/vaadin/spring/server/SpringUIProviderTestWithCustomAndDefaultNavigatorBean.java
@@ -16,11 +16,11 @@
 package com.vaadin.spring.server;
 
 import org.junit.Test;
+import org.springframework.beans.factory.NoUniqueBeanDefinitionException;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.web.WebAppConfiguration;
-import org.springframework.util.Assert;
 
 import com.vaadin.server.VaadinRequest;
 import com.vaadin.spring.annotation.EnableVaadinNavigation;
@@ -70,12 +70,11 @@ public class SpringUIProviderTestWithCustomAndDefaultNavigatorBean
         }
     }
 
-    @Test
+    @Test(expected = NoUniqueBeanDefinitionException.class)
     public void testGetNavigator() throws Exception {
         // need a UI for the scope of the Navigator
         TestUI ui = createUi(TestUI.class);
-        Assert.isNull(ui.getNavigator(),
-                "Selected a Navigator bean even though it is ambiguous");
+        ui.getNavigator();
     }
 
 }

--- a/vaadin-spring/src/test/java/com/vaadin/spring/server/SpringUIProviderTestWithCustomAndDefaultNavigatorBean.java
+++ b/vaadin-spring/src/test/java/com/vaadin/spring/server/SpringUIProviderTestWithCustomAndDefaultNavigatorBean.java
@@ -25,6 +25,7 @@ import org.springframework.util.Assert;
 import com.vaadin.server.VaadinRequest;
 import com.vaadin.spring.annotation.EnableVaadinNavigation;
 import com.vaadin.spring.annotation.SpringUI;
+import com.vaadin.spring.annotation.UIScope;
 import com.vaadin.spring.annotation.ViewContainer;
 import com.vaadin.spring.navigator.SpringNavigator;
 import com.vaadin.ui.UI;
@@ -57,6 +58,7 @@ public class SpringUIProviderTestWithCustomAndDefaultNavigatorBean
         // active by default, but explicitly defining a Navigator bean will
         // cause a conflict.
         @Bean
+        @UIScope
         public MyNavigator myNavigator() {
             return new MyNavigator();
         }
@@ -70,7 +72,9 @@ public class SpringUIProviderTestWithCustomAndDefaultNavigatorBean
 
     @Test
     public void testGetNavigator() throws Exception {
-        Assert.isNull(getUiProvider().getNavigator(),
+        // need a UI for the scope of the Navigator
+        TestUI ui = createUi(TestUI.class);
+        Assert.isNull(ui.getNavigator(),
                 "Selected a Navigator bean even though it is ambiguous");
     }
 

--- a/vaadin-spring/src/test/java/com/vaadin/spring/server/SpringUIProviderTestWithCustomNavigatorBean.java
+++ b/vaadin-spring/src/test/java/com/vaadin/spring/server/SpringUIProviderTestWithCustomNavigatorBean.java
@@ -22,38 +22,40 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.util.Assert;
 
-import com.vaadin.navigator.View;
-import com.vaadin.navigator.ViewDisplay;
+import com.vaadin.navigator.Navigator.SingleComponentContainerViewDisplay;
 import com.vaadin.server.VaadinRequest;
-import com.vaadin.spring.annotation.EnableVaadinNavigation;
 import com.vaadin.spring.annotation.SpringUI;
 import com.vaadin.spring.annotation.ViewContainer;
+import com.vaadin.spring.navigator.SpringNavigator;
 import com.vaadin.ui.UI;
 
 /**
- * Test for normal (full) use cases of SpringUIProvider with automatic
- * navigation configuration on the view and the UI implementing ViewDisplay.
+ * Test SpringUIProvider for the case where the application has a custom
+ * navigator bean.
  */
 @ContextConfiguration
 @WebAppConfiguration
-public class SpringUIProviderTestWithUiImplementingViewDisplayAsViewContainer
+public class SpringUIProviderTestWithCustomNavigatorBean
         extends AbstractSpringUIProviderTest {
 
     @SpringUI
     @ViewContainer
-    private static class TestUI extends UI implements ViewDisplay {
+    private static class TestUI extends UI {
         @Override
         protected void init(VaadinRequest request) {
         }
+    }
 
-        @Override
-        public void showView(View view) {
-        }
+    private static class MyNavigator extends SpringNavigator {
     }
 
     @Configuration
-    @EnableVaadinNavigation
     static class Config extends AbstractSpringUIProviderTest.Config {
+        @Bean
+        public MyNavigator myNavigator() {
+            return new MyNavigator();
+        }
+
         // this gets configured by the UI provider
         @Bean
         public TestUI ui() {
@@ -63,15 +65,17 @@ public class SpringUIProviderTestWithUiImplementingViewDisplayAsViewContainer
 
     @Test
     public void testGetNavigator() throws Exception {
-        Assert.notNull(getUiProvider().getNavigator(),
-                "Navigator not available in SpringUIProvider");
+        Assert.isInstanceOf(MyNavigator.class, getUiProvider().getNavigator(),
+                "Navigator is not a MyNavigator");
     }
 
     @Test
     public void testConfigureNavigator() {
         TestUI ui = createUi(TestUI.class);
-        Assert.isTrue(ui.getNavigator().getDisplay() instanceof TestUI,
-                "Navigator is not configured for a custom ViewDisplay");
+        Assert.isTrue(
+                ui.getNavigator()
+                        .getDisplay() instanceof SingleComponentContainerViewDisplay,
+                "Navigator is not configured with the correct type of ViewDisplay");
     }
 
     @Test

--- a/vaadin-spring/src/test/java/com/vaadin/spring/server/SpringUIProviderTestWithPanelAsViewContainer.java
+++ b/vaadin-spring/src/test/java/com/vaadin/spring/server/SpringUIProviderTestWithPanelAsViewContainer.java
@@ -25,16 +25,16 @@ import org.springframework.util.Assert;
 
 import com.vaadin.navigator.Navigator.SingleComponentContainerViewDisplay;
 import com.vaadin.server.VaadinRequest;
+import com.vaadin.spring.annotation.EnableVaadinNavigation;
 import com.vaadin.spring.annotation.SpringUI;
 import com.vaadin.spring.annotation.UIScope;
 import com.vaadin.spring.annotation.ViewContainer;
-import com.vaadin.spring.navigator.SpringNavigator;
 import com.vaadin.ui.Panel;
 import com.vaadin.ui.UI;
 
 /**
  * Test for normal (full) use cases of SpringUIProvider with automatic
- * navigation configuration on the view.
+ * navigation configuration on the view with a Panel as the view container.
  */
 @ContextConfiguration
 @WebAppConfiguration
@@ -55,12 +55,8 @@ public class SpringUIProviderTestWithPanelAsViewContainer
     }
 
     @Configuration
+    @EnableVaadinNavigation
     static class Config extends AbstractSpringUIProviderTest.Config {
-        @Bean
-        public SpringNavigator navigator() {
-            return new SpringNavigator();
-        }
-
         @Bean
         public MyPanel myPanel() {
             return new MyPanel();

--- a/vaadin-spring/src/test/java/com/vaadin/spring/server/SpringUIProviderTestWithUiImplementingViewDisplayAsViewContainer.java
+++ b/vaadin-spring/src/test/java/com/vaadin/spring/server/SpringUIProviderTestWithUiImplementingViewDisplayAsViewContainer.java
@@ -63,8 +63,10 @@ public class SpringUIProviderTestWithUiImplementingViewDisplayAsViewContainer
 
     @Test
     public void testGetNavigator() throws Exception {
-        Assert.notNull(getUiProvider().getNavigator(),
-                "Navigator not available in SpringUIProvider");
+        // need a UI for the scope of the Navigator
+        TestUI ui = createUi(TestUI.class);
+        Assert.notNull(ui.getNavigator(),
+                "Navigator not available from SpringUIProvider");
     }
 
     @Test

--- a/vaadin-spring/src/test/java/com/vaadin/spring/server/SpringUIProviderTestWithoutViewContainer.java
+++ b/vaadin-spring/src/test/java/com/vaadin/spring/server/SpringUIProviderTestWithoutViewContainer.java
@@ -23,13 +23,13 @@ import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.util.Assert;
 
 import com.vaadin.server.VaadinRequest;
+import com.vaadin.spring.annotation.EnableVaadinNavigation;
 import com.vaadin.spring.annotation.SpringUI;
-import com.vaadin.spring.navigator.SpringNavigator;
 import com.vaadin.ui.UI;
 
 /**
  * Test for normal (full) use cases of SpringUIProvider with automatic
- * navigation configuration on the view.
+ * navigation configuration on the view but no view container defined.
  */
 @ContextConfiguration
 @WebAppConfiguration
@@ -44,12 +44,8 @@ public class SpringUIProviderTestWithoutViewContainer
     }
 
     @Configuration
+    @EnableVaadinNavigation
     static class Config extends AbstractSpringUIProviderTest.Config {
-        @Bean
-        public SpringNavigator navigator() {
-            return new SpringNavigator();
-        }
-
         // this gets configured by the UI provider
         @Bean
         public TestUI ui() {

--- a/vaadin-spring/src/test/java/com/vaadin/spring/test/util/SingletonBeanStoreRetrievalStrategy.java
+++ b/vaadin-spring/src/test/java/com/vaadin/spring/test/util/SingletonBeanStoreRetrievalStrategy.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2015 The original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.vaadin.spring.test.util;
+
+import com.vaadin.spring.internal.BeanStore;
+import com.vaadin.spring.internal.BeanStoreRetrievalStrategy;
+
+/**
+ * Singleton bean store retrieval strategy that always returns the same bean
+ * store and conversation id. This strategy is primarily a helper for testing.
+ */
+public class SingletonBeanStoreRetrievalStrategy
+        implements BeanStoreRetrievalStrategy {
+
+    public static final String CONVERSATION_ID = "testConversation";
+    private BeanStore beanStore = new BeanStore("testBeanStore");
+
+    @Override
+    public BeanStore getBeanStore() {
+        return beanStore;
+    }
+
+    @Override
+    public String getConversationId() {
+        return CONVERSATION_ID;
+    }
+
+}

--- a/vaadin-spring/src/test/java/com/vaadin/spring/test/util/TestSpringVaadinServletService.java
+++ b/vaadin-spring/src/test/java/com/vaadin/spring/test/util/TestSpringVaadinServletService.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2015 The original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.vaadin.spring.test.util;
+
+import java.util.Properties;
+
+import org.springframework.web.context.WebApplicationContext;
+
+import com.vaadin.server.DefaultDeploymentConfiguration;
+import com.vaadin.server.ServiceException;
+import com.vaadin.server.VaadinServlet;
+import com.vaadin.spring.server.SpringVaadinServletService;
+
+// override methods to increase their visibility
+public class TestSpringVaadinServletService extends SpringVaadinServletService {
+    private WebApplicationContext applicationContext;
+
+    public TestSpringVaadinServletService(VaadinServlet servlet,
+            WebApplicationContext applicationContext) throws ServiceException {
+        super(servlet,
+                new DefaultDeploymentConfiguration(
+                        TestSpringVaadinServletService.class, new Properties()),
+                "");
+        this.applicationContext = applicationContext;
+        init();
+    }
+
+    @Override
+    public WebApplicationContext getWebApplicationContext() {
+        return applicationContext;
+    }
+}

--- a/vaadin-spring/src/test/java/com/vaadin/spring/test/util/TestVaadinSession.java
+++ b/vaadin-spring/src/test/java/com/vaadin/spring/test/util/TestVaadinSession.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2015 The original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.vaadin.spring.test.util;
+
+import org.springframework.web.context.WebApplicationContext;
+
+import com.vaadin.server.ServiceException;
+import com.vaadin.server.VaadinSession;
+import com.vaadin.spring.server.SpringVaadinServlet;
+
+public class TestVaadinSession extends VaadinSession {
+
+    public TestVaadinSession(WebApplicationContext applicationContext)
+            throws ServiceException {
+        super(new TestSpringVaadinServletService(new SpringVaadinServlet(),
+                applicationContext));
+    }
+
+    @Override
+    public boolean hasLock() {
+        return true;
+    }
+
+}


### PR DESCRIPTION
Add @EnableVaadinNavigation that automatically defines a navigator bean
when applied on a @Configuration.

Enable the annotation by default in Spring Boot applications.

Add/update related tests.

Closes #99

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/spring/101)
<!-- Reviewable:end -->
