### PR TITLE
Do not disable ViewContainerPostProcessor too eagerly

### DIFF
--- a/vaadin-spring-boot/src/main/java/com/vaadin/spring/boot/VaadinAutoConfiguration.java
+++ b/vaadin-spring-boot/src/main/java/com/vaadin/spring/boot/VaadinAutoConfiguration.java
@@ -20,12 +20,15 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import com.vaadin.spring.annotation.EnableVaadin;
-import com.vaadin.spring.annotation.EnableVaadinNavigation;
 import com.vaadin.spring.annotation.SpringUI;
+import com.vaadin.spring.annotation.UIScope;
 import com.vaadin.spring.boot.annotation.EnableVaadinServlet;
+import com.vaadin.spring.internal.ViewContainerPostProcessor;
+import com.vaadin.spring.navigator.SpringNavigator;
 
 /**
  * @author Petter Holmström (petter@vaadin.com)
@@ -50,10 +53,22 @@ public class VaadinAutoConfiguration {
     }
 
     @Configuration
-    @EnableVaadinNavigation
-    @ConditionalOnMissingBean(type = "com.vaadin.spring.navigator.SpringNavigator")
+    // not using @EnableVaadinNavigation to enable each bean to have its own
+    // condition
     static class EnableVaadinNavigatorConfiguration
             implements InitializingBean {
+        @ConditionalOnMissingBean(type = "com.vaadin.spring.navigator.SpringNavigator")
+        @Bean
+        @UIScope
+        public SpringNavigator vaadinNavigator() {
+            return new SpringNavigator();
+        }
+
+        @Bean
+        public static ViewContainerPostProcessor viewContainerPostProcessor() {
+            return new ViewContainerPostProcessor();
+        }
+
         @Override
         public void afterPropertiesSet() throws Exception {
             logger.debug("{} initialized", getClass().getName());


### PR DESCRIPTION
Defining a SpringNavigator bean should not also disable @ViewContainer
support.

Fixes #134

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/spring/135)
<!-- Reviewable:end -->
