### PR TITLE
Optimize by changing the order of checks

### DIFF
--- a/vaadin-spring/src/main/java/com/vaadin/spring/server/SpringUIProvider.java
+++ b/vaadin-spring/src/main/java/com/vaadin/spring/server/SpringUIProvider.java
@@ -263,12 +263,14 @@ public class SpringUIProvider extends UIProvider {
      *            automatic navigation
      */
     protected void configureNavigator(UI ui) {
-        Object viewContainer = findViewContainer(ui);
-        if (viewContainer == null) {
-            return;
-        }
+        // this test first as it is cheaper than looking for ViewContainers
+        // in case the backup mechanism would be used
         SpringNavigator navigator = getNavigator();
         if (navigator == null) {
+            return;
+        }
+        Object viewContainer = findViewContainer(ui);
+        if (viewContainer == null) {
             return;
         }
 


### PR DESCRIPTION
Checking for @ViewContainer beans can be more expensive than looking for
a SpringNavigator.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/spring/139)
<!-- Reviewable:end -->
