### PR TITLE
Properly guard absence of SpringNavigator

### DIFF
--- a/vaadin-spring-boot/src/main/java/com/vaadin/spring/boot/VaadinAutoConfiguration.java
+++ b/vaadin-spring-boot/src/main/java/com/vaadin/spring/boot/VaadinAutoConfiguration.java
@@ -57,12 +57,6 @@ public class VaadinAutoConfiguration {
     // condition
     static class EnableVaadinNavigatorConfiguration
             implements InitializingBean {
-        @ConditionalOnMissingBean(type = "com.vaadin.spring.navigator.SpringNavigator")
-        @Bean
-        @UIScope
-        public SpringNavigator vaadinNavigator() {
-            return new SpringNavigator();
-        }
 
         @Bean
         public static SpringViewDisplayPostProcessor springViewDisplayPostProcessor() {
@@ -74,6 +68,25 @@ public class VaadinAutoConfiguration {
             logger.debug("{} initialized", getClass().getName());
         }
     }
+
+	@Configuration
+	@ConditionalOnClass(name = "com.vaadin.spring.navigator.SpringNavigator")
+	static class EnableSpringVaadinNavigatorConfiguration
+			implements InitializingBean {
+
+		@ConditionalOnMissingBean(type = "com.vaadin.spring.navigator.SpringNavigator")
+		@Bean
+		@UIScope
+		public SpringNavigator vaadinNavigator() {
+			return new SpringNavigator();
+		}
+
+		@Override
+		public void afterPropertiesSet() throws Exception {
+			logger.debug("{} initialized", getClass().getName());
+		}
+
+	}
 
     @Configuration
     @EnableVaadinServlet


### PR DESCRIPTION
Since `SpringNavigator` may not be present, it should be properly guarded
with an additional `ConditionalOnType` at class level. That way, the whole
processing of the `@Configuration` class will be skipped.

To avoid `SpringViewDisplayPostProcessor` to not be registered in such a
case, the registration of `SpringNavigator` has been moved to its own
configuration class.

Closes gh-151

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/spring/154)
<!-- Reviewable:end -->
