### PR TITLE
Support serialisation in 1.1

### DIFF
--- a/vaadin-spring-boot/src/main/java/com/vaadin/spring/boot/VaadinAutoConfiguration.java
+++ b/vaadin-spring-boot/src/main/java/com/vaadin/spring/boot/VaadinAutoConfiguration.java
@@ -29,6 +29,8 @@ import com.vaadin.spring.annotation.UIScope;
 import com.vaadin.spring.boot.annotation.EnableVaadinServlet;
 import com.vaadin.spring.internal.SpringViewDisplayPostProcessor;
 import com.vaadin.spring.navigator.SpringNavigator;
+import com.vaadin.spring.navigator.SpringViewProvider;
+import org.springframework.context.ApplicationContext;
 
 /**
  * @author Petter Holmström (petter@vaadin.com)
@@ -77,8 +79,8 @@ public class VaadinAutoConfiguration {
 		@ConditionalOnMissingBean(type = "com.vaadin.spring.navigator.SpringNavigator")
 		@Bean
 		@UIScope
-		public SpringNavigator vaadinNavigator() {
-			return new SpringNavigator();
+		public SpringNavigator vaadinNavigator(ApplicationContext applicationContext, SpringViewProvider viewProvider) {
+			return new SpringNavigator(applicationContext, viewProvider);
 		}
 
 		@Override

--- a/vaadin-spring-boot/src/test/java/com/vaadin/spring/boot/VaadinAutoConfigurationWithCustomNavigatorTest.java
+++ b/vaadin-spring-boot/src/test/java/com/vaadin/spring/boot/VaadinAutoConfigurationWithCustomNavigatorTest.java
@@ -32,7 +32,9 @@ import com.vaadin.spring.annotation.SpringUI;
 import com.vaadin.spring.annotation.SpringViewDisplay;
 import com.vaadin.spring.annotation.UIScope;
 import com.vaadin.spring.navigator.SpringNavigator;
+import com.vaadin.spring.navigator.SpringViewProvider;
 import com.vaadin.spring.server.AbstractSpringUIProviderTest;
+import org.springframework.context.ApplicationContext;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration
@@ -51,6 +53,10 @@ public class VaadinAutoConfigurationWithCustomNavigatorTest
     }
 
     private static class MyNavigator extends SpringNavigator {
+
+        public MyNavigator(ApplicationContext applicationContext, SpringViewProvider viewProvider) {
+            super(applicationContext, viewProvider);
+        }
     }
 
     @Configuration
@@ -60,8 +66,8 @@ public class VaadinAutoConfigurationWithCustomNavigatorTest
     protected static class Config {
         @Bean
         @UIScope
-        public MyNavigator myNavigator() {
-            return new MyNavigator();
+        public MyNavigator myNavigator(ApplicationContext applicationContext, SpringViewProvider viewProvider) {
+            return new MyNavigator(applicationContext, viewProvider);
         }
 
         // this gets configured by the UI provider

--- a/vaadin-spring/src/main/java/com/vaadin/spring/VaadinNavigatorConfiguration.java
+++ b/vaadin-spring/src/main/java/com/vaadin/spring/VaadinNavigatorConfiguration.java
@@ -22,6 +22,8 @@ import com.vaadin.spring.annotation.EnableVaadinNavigation;
 import com.vaadin.spring.annotation.UIScope;
 import com.vaadin.spring.internal.SpringViewDisplayPostProcessor;
 import com.vaadin.spring.navigator.SpringNavigator;
+import com.vaadin.spring.navigator.SpringViewProvider;
+import org.springframework.context.ApplicationContext;
 
 /**
  * Spring configuration for automatically configuring a SpringNavigator.
@@ -37,8 +39,8 @@ public class VaadinNavigatorConfiguration {
 
     @Bean
     @UIScope
-    public SpringNavigator vaadinNavigator() {
-        return new SpringNavigator();
+    public SpringNavigator vaadinNavigator(ApplicationContext applicationContext, SpringViewProvider viewProvider) {
+        return new SpringNavigator(applicationContext, viewProvider);
     }
 
     @Bean

--- a/vaadin-spring/src/test/java/com/vaadin/spring/internal/SpringViewProviderAccessControlTest.java
+++ b/vaadin-spring/src/test/java/com/vaadin/spring/internal/SpringViewProviderAccessControlTest.java
@@ -50,6 +50,7 @@ import com.vaadin.spring.server.AbstractSpringUIProviderTest;
 import com.vaadin.spring.test.util.TestSpringNavigator;
 import com.vaadin.ui.UI;
 import com.vaadin.util.CurrentInstance;
+import org.springframework.context.ApplicationContext;
 
 /**
  * Test SpringViewProvider access control.
@@ -176,8 +177,8 @@ public class SpringViewProviderAccessControlTest
 
         @Bean
         @UIScope
-        public SpringNavigator vaadinNavigator() {
-            return new TestSpringNavigator();
+        public SpringNavigator vaadinNavigator(ApplicationContext applicationContext, SpringViewProvider viewProvider) {
+            return new TestSpringNavigator(applicationContext, viewProvider);
         }
     }
 

--- a/vaadin-spring/src/test/java/com/vaadin/spring/internal/SpringViewProviderTest.java
+++ b/vaadin-spring/src/test/java/com/vaadin/spring/internal/SpringViewProviderTest.java
@@ -45,6 +45,7 @@ import com.vaadin.spring.server.AbstractSpringUIProviderTest;
 import com.vaadin.spring.test.util.TestSpringNavigator;
 import com.vaadin.ui.UI;
 import com.vaadin.util.CurrentInstance;
+import org.springframework.context.ApplicationContext;
 
 /**
  * Test SpringViewProvider.
@@ -148,10 +149,11 @@ public class SpringViewProviderTest extends AbstractSpringUIProviderTest {
         	return new TestView5();
         }
 
+        
         @Bean
         @UIScope
-        public SpringNavigator vaadinNavigator() {
-            return new TestSpringNavigator();
+        public SpringNavigator vaadinNavigator(ApplicationContext applicationContext, SpringViewProvider viewProvider) {
+            return new TestSpringNavigator(applicationContext, viewProvider);
         }
     }
 

--- a/vaadin-spring/src/test/java/com/vaadin/spring/server/SpringUIProviderTestWithCustomAndDefaultNavigatorBean.java
+++ b/vaadin-spring/src/test/java/com/vaadin/spring/server/SpringUIProviderTestWithCustomAndDefaultNavigatorBean.java
@@ -27,6 +27,8 @@ import com.vaadin.spring.annotation.SpringUI;
 import com.vaadin.spring.annotation.UIScope;
 import com.vaadin.spring.annotation.SpringViewDisplay;
 import com.vaadin.spring.navigator.SpringNavigator;
+import com.vaadin.spring.navigator.SpringViewProvider;
+import org.springframework.context.ApplicationContext;
 
 /**
  * Test SpringUIProvider for the case where the application has a custom
@@ -43,6 +45,10 @@ public class SpringUIProviderTestWithCustomAndDefaultNavigatorBean
     }
 
     private static class MyNavigator extends SpringNavigator {
+
+        public MyNavigator(ApplicationContext applicationContext, SpringViewProvider viewProvider) {
+            super(applicationContext, viewProvider);
+        }
     }
 
     @Configuration
@@ -54,8 +60,8 @@ public class SpringUIProviderTestWithCustomAndDefaultNavigatorBean
         // cause a conflict.
         @Bean
         @UIScope
-        public MyNavigator myNavigator() {
-            return new MyNavigator();
+        public MyNavigator myNavigator(ApplicationContext applicationContext, SpringViewProvider viewProvider) {
+            return new MyNavigator(applicationContext, viewProvider);
         }
 
         // this gets configured by the UI provider

--- a/vaadin-spring/src/test/java/com/vaadin/spring/server/SpringUIProviderTestWithCustomNavigatorBean.java
+++ b/vaadin-spring/src/test/java/com/vaadin/spring/server/SpringUIProviderTestWithCustomNavigatorBean.java
@@ -25,7 +25,10 @@ import org.springframework.util.Assert;
 
 import com.vaadin.navigator.Navigator.SingleComponentContainerViewDisplay;
 import com.vaadin.spring.annotation.SpringUI;
+import com.vaadin.spring.annotation.UIScope;
 import com.vaadin.spring.navigator.SpringNavigator;
+import com.vaadin.spring.navigator.SpringViewProvider;
+import org.springframework.context.ApplicationContext;
 
 /**
  * Test SpringUIProvider for the case where the application has a custom
@@ -42,13 +45,19 @@ public class SpringUIProviderTestWithCustomNavigatorBean
     }
 
     private static class MyNavigator extends SpringNavigator {
+
+        public MyNavigator(ApplicationContext applicationContext, SpringViewProvider viewProvider) {
+            super(applicationContext, viewProvider);
+        }
     }
 
     @Configuration
     static class Config extends AbstractSpringUIProviderTest.Config {
+
         @Bean
-        public MyNavigator myNavigator() {
-            return new MyNavigator();
+        @UIScope
+        public MyNavigator myNavigator(ApplicationContext applicationContext, SpringViewProvider viewProvider) {
+            return new MyNavigator(applicationContext, viewProvider);
         }
 
         // this gets configured by the UI provider

--- a/vaadin-spring/src/test/java/com/vaadin/spring/test/util/TestSpringNavigator.java
+++ b/vaadin-spring/src/test/java/com/vaadin/spring/test/util/TestSpringNavigator.java
@@ -20,10 +20,17 @@ import com.vaadin.navigator.Navigator;
 import com.vaadin.navigator.View;
 import com.vaadin.navigator.ViewDisplay;
 import com.vaadin.spring.navigator.SpringNavigator;
+import com.vaadin.spring.navigator.SpringViewProvider;
 import com.vaadin.ui.UI;
+import org.springframework.context.ApplicationContext;
 
 // customized navigator to bypass most dependencies
 public final class TestSpringNavigator extends SpringNavigator {
+
+    public TestSpringNavigator(ApplicationContext applicationContext, SpringViewProvider viewProvider) {
+        super(applicationContext, viewProvider);
+    }
+    
     @Override
     public void init(UI ui, ViewDisplay display) {
         init(ui, new NavigationStateManager() {


### PR DESCRIPTION
1.1 release introduced a regression regarding session serialisation. There is 
a new direct reference to ApplicationContext. This pull request fixes
that in the same way as @Artur- fixed the previous serialization issue for 1.0.x release.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/spring/157)
<!-- Reviewable:end -->
