### PR TITLE
Support serialization in 1.1

### DIFF
--- a/vaadin-spring/src/main/java/com/vaadin/spring/server/SpringUIProvider.java
+++ b/vaadin-spring/src/main/java/com/vaadin/spring/server/SpringUIProvider.java
@@ -71,7 +71,7 @@ public class SpringUIProvider extends UIProvider {
     private final Map<String, Class<? extends UI>> pathToUIMap = new ConcurrentHashMap<String, Class<? extends UI>>();
     private final Map<String, Class<? extends UI>> wildcardPathToUIMap = new ConcurrentHashMap<String, Class<? extends UI>>();
 
-    private ServletContext servletContext;
+    private transient ServletContext servletContext;
 
     public SpringUIProvider(VaadinSession vaadinSession) {
         this.vaadinSession = vaadinSession;


### PR DESCRIPTION
1.1 release introduced a regression regarding session serialisation. There is
a new direct reference to ApplicationContext. This pull request fixes
that in the same way as @Artur- fixed the previous serialization issue for 1.0.x release.

Replaces pull request #157

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/spring/158)
<!-- Reviewable:end -->
