### PR TITLE
Use AnnotatedElementUtils for annotation lookup to support @AliasFor

### DIFF
--- a/vaadin-spring/src/main/java/com/vaadin/spring/navigator/SpringViewProvider.java
+++ b/vaadin-spring/src/main/java/com/vaadin/spring/navigator/SpringViewProvider.java
@@ -36,6 +36,7 @@ import org.springframework.beans.factory.config.AutowireCapableBeanFactory;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 import org.springframework.context.ApplicationContext;
+import org.springframework.core.annotation.AnnotatedElementUtils;
 import org.springframework.util.Assert;
 
 import com.vaadin.navigator.View;
@@ -176,8 +177,8 @@ public class SpringViewProvider implements ViewProvider {
         for (String beanName : viewBeanNames) {
             final Class<?> type = getWebApplicationContext().getType(beanName);
             if (View.class.isAssignableFrom(type)) {
-                final SpringView annotation = getWebApplicationContext()
-                        .findAnnotationOnBean(beanName, SpringView.class);
+                final SpringView annotation = AnnotatedElementUtils
+                        .findMergedAnnotation(type, SpringView.class);
                 final String viewName = getViewNameFromAnnotation(type,
                         annotation);
                 LOGGER.debug("Found SpringView bean [{}] with view name [{}]",


### PR DESCRIPTION
`getWebApplicationContext().findAnnotationOnBean()` used by SpringViewProvider only returns the top level annotation which does not allow developers to utilize @AliasFor annotation. By replacing it with `AnnotatedElementUtils` developers may use @SpringView annotation as meta-annotation like in the following example:

```
// This sample annotation serves only demonstration purpose so it might not have practical benefit
@UIScope
@SpringView
@Target({ java.lang.annotation.ElementType.TYPE })
@Retention(java.lang.annotation.RetentionPolicy.RUNTIME)
public @interface UIScopedSpringView {

    @AliasFor(annotation = SpringView.class, attribute = "name")
    String value() default USE_CONVENTIONS;

    public static final String USE_CONVENTIONS = "USE CONVENTIONS";

    @AliasFor(annotation = SpringView.class, attribute = "ui")
    Class<? extends UI>[] ui() default {};
}
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/spring/183)
<!-- Reviewable:end -->
