### PR TITLE
Avoid duplicate registration of SpringViewDisplayRegistrationBean

### DIFF
--- a/vaadin-spring/src/main/java/com/vaadin/spring/internal/SpringViewDisplayRegistrationBean.java
+++ b/vaadin-spring/src/main/java/com/vaadin/spring/internal/SpringViewDisplayRegistrationBean.java
@@ -67,4 +67,22 @@ public class SpringViewDisplayRegistrationBean implements Serializable {
         this.beanName = beanName;
     }
 
+    /**
+     * Returns the view display bean class (if set).
+     *
+     * @return view display bean class or null if using bean name
+     */
+    public Class<?> getBeanClass() {
+        return beanClass;
+    }
+
+    /**
+     * Returns the view display bean name (if set).
+     *
+     * @return view display bean name or null if using bean class
+     */
+    public String getBeanName() {
+        return beanName;
+    }
+
 }


### PR DESCRIPTION
Register SVDRB instances in synchronized methods after a check for
existing instances.

This fixes behavior under heavy stress as well as JRebel/DCEVM reload
issues.

Note that this does not address the somewhat related #163.

Fixes #203
Fixes #200
Fixes #184

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/spring/204)
<!-- Reviewable:end -->
