### PR TITLE
Avoid duplicate registration of SpringViewDisplayRegistrationBean

### DIFF
--- a/vaadin-spring/src/main/java/com/vaadin/spring/internal/SpringViewDisplayPostProcessor.java
+++ b/vaadin-spring/src/main/java/com/vaadin/spring/internal/SpringViewDisplayPostProcessor.java
@@ -15,10 +15,8 @@
  */
 package com.vaadin.spring.internal;
 
-import com.vaadin.navigator.ViewDisplay;
-import com.vaadin.spring.annotation.SpringViewDisplay;
-import com.vaadin.spring.server.SpringUIProvider;
-import com.vaadin.ui.Component;
+import java.util.Map;
+
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.BeanDefinitionStoreException;
 import org.springframework.beans.factory.BeanFactory;
@@ -36,11 +34,14 @@ import org.springframework.context.ApplicationContextAware;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.core.type.StandardMethodMetadata;
 
-import java.util.Map;
+import com.vaadin.navigator.ViewDisplay;
+import com.vaadin.spring.annotation.SpringViewDisplay;
+import com.vaadin.spring.server.SpringUIProvider;
+import com.vaadin.ui.Component;
 
 /**
- * Bean post processor that scans for {@link SpringViewDisplay} annotations on UI
- * scoped beans or bean classes and registers
+ * Bean post processor that scans for {@link SpringViewDisplay} annotations on
+ * UI scoped beans or bean classes and registers
  * {@link SpringViewDisplayRegistrationBean} instances for them for
  * {@link SpringUIProvider}.
  *
@@ -72,7 +73,8 @@ public class SpringViewDisplayPostProcessor implements BeanPostProcessor,
                 StandardMethodMetadata metadata = (StandardMethodMetadata) beanDefinition
                         .getSource();
                 Map<String, Object> annotationAttributes = metadata
-                        .getAnnotationAttributes(SpringViewDisplay.class.getName());
+                        .getAnnotationAttributes(
+                                SpringViewDisplay.class.getName());
                 if (annotationAttributes != null) {
                     registerSpringViewDisplayBean(beanName);
                 }
@@ -89,19 +91,23 @@ public class SpringViewDisplayPostProcessor implements BeanPostProcessor,
      * Create a view display registration bean definition to allow accessing
      * annotated view displays for the current UI scope.
      *
-     * @param clazz bean class having the view display annotation, not null
+     * @param clazz
+     *            bean class having the view display annotation, not null
      */
-    protected void registerSpringViewDisplayBean(Class<?> clazz) {
+    protected synchronized void registerSpringViewDisplayBean(Class<?> clazz) {
         BeanDefinitionRegistry registry = null;
         if (applicationContext instanceof BeanDefinitionRegistry) {
             registry = (BeanDefinitionRegistry) applicationContext;
         } else if (applicationContext instanceof ConfigurableApplicationContext) {
-            ConfigurableListableBeanFactory beanFactory = ((ConfigurableApplicationContext) applicationContext).getBeanFactory();
-            if (beanFactory instanceof BeanDefinitionRegistry)
+            ConfigurableListableBeanFactory beanFactory = ((ConfigurableApplicationContext) applicationContext)
+                    .getBeanFactory();
+            if (beanFactory instanceof BeanDefinitionRegistry) {
                 registry = (BeanDefinitionRegistry) beanFactory;
+            }
         }
         if (registry == null) {
-            throw new BeanDefinitionStoreException("BeanDefinitionRegistry is not accessible");
+            throw new BeanDefinitionStoreException(
+                    "BeanDefinitionRegistry is not accessible");
         }
 
         BeanDefinitionBuilder builder = BeanDefinitionBuilder
@@ -116,17 +122,30 @@ public class SpringViewDisplayPostProcessor implements BeanPostProcessor,
         AbstractBeanDefinition beanDefinition = builder.getBeanDefinition();
         String name = getBeanNameGenerator().generateBeanName(beanDefinition,
                 registry);
-        registry.registerBeanDefinition(name, beanDefinition);
+
+        boolean alreadyRegistered = false;
+        Map<String, SpringViewDisplayRegistrationBean> registeredBeans = applicationContext
+                .getBeansOfType(SpringViewDisplayRegistrationBean.class);
+
+        for (SpringViewDisplayRegistrationBean registrationBean : registeredBeans.values()) {
+            if(clazz.equals(registrationBean.getBeanClass())) {
+                alreadyRegistered = true;
+                break;
+            }
+        }
+        if (!alreadyRegistered) {
+            registry.registerBeanDefinition(name, beanDefinition);
+        }
     }
 
     /**
      * Create a view display registration bean definition to allow accessing
      * annotated view displays for the current UI scope.
      *
-     * @param beanName name of the bean having the view display annotation, not
-     *                 null
+     * @param beanName
+     *            name of the bean having the view display annotation, not null
      */
-    protected void registerSpringViewDisplayBean(String beanName) {
+    protected synchronized void registerSpringViewDisplayBean(String beanName) {
         BeanDefinitionRegistry registry = (BeanDefinitionRegistry) applicationContext;
         BeanDefinitionBuilder builder = BeanDefinitionBuilder
                 .genericBeanDefinition(SpringViewDisplayRegistrationBean.class);
@@ -140,7 +159,18 @@ public class SpringViewDisplayPostProcessor implements BeanPostProcessor,
         AbstractBeanDefinition beanDefinition = builder.getBeanDefinition();
         String name = getBeanNameGenerator().generateBeanName(beanDefinition,
                 registry);
-        registry.registerBeanDefinition(name, beanDefinition);
+        boolean alreadyRegistered = false;
+        Map<String, SpringViewDisplayRegistrationBean> registeredBeans = applicationContext
+                .getBeansOfType(SpringViewDisplayRegistrationBean.class);
+        for (SpringViewDisplayRegistrationBean registrationBean : registeredBeans.values()) {
+            if(beanName.equals(registrationBean.getBeanName())) {
+                alreadyRegistered = true;
+                break;
+            }
+        }
+        if (!alreadyRegistered) {
+            registry.registerBeanDefinition(name, beanDefinition);
+        }
     }
 
     @Override

--- a/vaadin-spring/src/main/java/com/vaadin/spring/internal/SpringViewDisplayRegistrationBean.java
+++ b/vaadin-spring/src/main/java/com/vaadin/spring/internal/SpringViewDisplayRegistrationBean.java
@@ -67,4 +67,22 @@ public class SpringViewDisplayRegistrationBean implements Serializable {
         this.beanName = beanName;
     }
 
+    /**
+     * Returns the view display bean class (if set).
+     *
+     * @return view display bean class or null if using bean name
+     */
+    public Class<?> getBeanClass() {
+        return beanClass;
+    }
+
+    /**
+     * Returns the view display bean name (if set).
+     *
+     * @return view display bean name or null if using bean class
+     */
+    public String getBeanName() {
+        return beanName;
+    }
+
 }


### PR DESCRIPTION
Register SVDRB instances in synchronized methods after a check for
existing instances.

This fixes behavior under heavy stress as well as JRebel/DCEVM reload
issues.

Note that this does not address the somewhat related #163.

Fixes #203
Fixes #200
Fixes #184

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/spring/206)
<!-- Reviewable:end -->
