### PR TITLE
Let the framework invoke service init listener beans

### DIFF
--- a/vaadin-spring/src/main/java/com/vaadin/spring/server/SpringVaadinServlet.java
+++ b/vaadin-spring/src/main/java/com/vaadin/spring/server/SpringVaadinServlet.java
@@ -15,35 +15,32 @@
  */
 package com.vaadin.spring.server;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.context.support.WebApplicationContextUtils;
+
 import com.vaadin.server.DefaultUIProvider;
 import com.vaadin.server.DeploymentConfiguration;
 import com.vaadin.server.ServiceException;
-import com.vaadin.server.ServiceInitEvent;
 import com.vaadin.server.SessionDestroyEvent;
 import com.vaadin.server.SessionDestroyListener;
 import com.vaadin.server.SessionInitEvent;
 import com.vaadin.server.SessionInitListener;
 import com.vaadin.server.UIProvider;
-import com.vaadin.server.VaadinServiceInitListener;
 import com.vaadin.server.VaadinServlet;
 import com.vaadin.server.VaadinServletRequest;
 import com.vaadin.server.VaadinServletService;
 import com.vaadin.server.VaadinSession;
 import com.vaadin.spring.internal.UIScopeImpl;
 import com.vaadin.spring.internal.VaadinSessionScope;
-
-import org.springframework.web.context.WebApplicationContext;
-import org.springframework.web.context.support.WebApplicationContextUtils;
-
-import java.io.UnsupportedEncodingException;
-import java.net.URLDecoder;
-import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
 
 /**
  * Subclass of the standard {@link com.vaadin.server.VaadinServlet Vaadin
@@ -114,17 +111,6 @@ public class SpringVaadinServlet extends VaadinServlet {
                 VaadinSessionScope.cleanupSession(session);
             }
         });
-
-        WebApplicationContext webApplicationContext = WebApplicationContextUtils
-                .getWebApplicationContext(getServletContext());
-
-        final Map<String, VaadinServiceInitListener> serviceInitListeners = webApplicationContext.getBeansOfType(VaadinServiceInitListener.class);
-
-        ServiceInitEvent event = new ServiceInitEvent(service);
-
-        for (VaadinServiceInitListener vaadinServiceInitListener : serviceInitListeners.values()) {
-            vaadinServiceInitListener.serviceInit(event);
-        }
     }
 
     /**

--- a/vaadin-spring/src/main/java/com/vaadin/spring/server/SpringVaadinServletService.java
+++ b/vaadin-spring/src/main/java/com/vaadin/spring/server/SpringVaadinServletService.java
@@ -15,7 +15,10 @@
  */
 package com.vaadin.spring.server;
 
+import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 
 import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.context.support.WebApplicationContextUtils;
@@ -23,6 +26,7 @@ import org.springframework.web.context.support.WebApplicationContextUtils;
 import com.vaadin.server.DeploymentConfiguration;
 import com.vaadin.server.RequestHandler;
 import com.vaadin.server.ServiceException;
+import com.vaadin.server.VaadinServiceInitListener;
 import com.vaadin.server.VaadinServlet;
 import com.vaadin.server.VaadinServletService;
 import com.vaadin.server.communication.ServletBootstrapHandler;
@@ -82,5 +86,20 @@ public class SpringVaadinServletService extends VaadinServletService {
     public WebApplicationContext getWebApplicationContext() {
         return WebApplicationContextUtils
                 .getWebApplicationContext(getServlet().getServletContext());
+    }
+
+    @Override
+    protected Iterator<VaadinServiceInitListener> getServiceInitListeners() {
+        // Collect from both sources to return a combined iterator
+        ArrayList<VaadinServiceInitListener> listeners = new ArrayList<>();
+
+        Iterator<VaadinServiceInitListener> superListeners = super.getServiceInitListeners();
+        superListeners.forEachRemaining(listeners::add);
+
+        Map<String, VaadinServiceInitListener> listenerBeans = getWebApplicationContext()
+                .getBeansOfType(VaadinServiceInitListener.class);
+        listeners.addAll(listenerBeans.values());
+
+        return listeners.iterator();
     }
 }


### PR DESCRIPTION
Integrate discovery of listeners that are spring beans into the regular
init listener discovery so that those listeners will be invoked in the
same way as regular listeners. Without this, additional listeners added
through the session init event would be discarded.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/spring/223)
<!-- Reviewable:end -->
