### PR TITLE
Skip listener removal if UI is not available

### DIFF
--- a/vaadin-spring/src/main/java/com/vaadin/spring/internal/DefaultViewCache.java
+++ b/vaadin-spring/src/main/java/com/vaadin/spring/internal/DefaultViewCache.java
@@ -193,11 +193,14 @@ public class DefaultViewCache implements ViewCache {
                 beanStores.values())) {
             beanStore.destroy();
         }
-        Navigator navigator = getCurrentUI().getNavigator();
-        if (navigator instanceof SpringNavigator) {
-            // not in legacy mode
-            ((SpringNavigator) navigator)
-                    .removeViewActivationListener(listener);
+        UI currentUi = getCurrentUI();
+        if (currentUi != null) {
+            Navigator navigator = currentUi.getNavigator();
+            if (navigator instanceof SpringNavigator) {
+                // not in legacy mode
+                ((SpringNavigator) navigator)
+                        .removeViewActivationListener(listener);
+            }
         }
         Assert.isTrue(beanStores.isEmpty(),
                 "beanStores should have been emptied by the destruction callbacks");


### PR DESCRIPTION
If there would be a memory leak from the listener registration, GC
will take care of it when the session expires.

Fixes #202

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/spring/225)
<!-- Reviewable:end -->
