### PR TITLE
Fix Spring UI paths with PushState based navigation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         
         <!-- These are typically overridden with BOMs -->
-        <vaadin.version>8.2-SNAPSHOT</vaadin.version>
+        <vaadin.version>8.2.0.beta1</vaadin.version>
         <spring.version>4.3.9.RELEASE</spring.version>
         <spring.security.version>4.2.3.RELEASE</spring.security.version>
         <spring.boot.version>1.4.7.RELEASE</spring.boot.version>
@@ -204,6 +204,11 @@
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>
+        </repository>
+        <!-- TODO: Remove when going final -->
+        <repository>
+            <id>vaadin-prereleases</id>
+            <url>http://maven.vaadin.com/vaadin-prereleases</url>
         </repository>
     </repositories>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>com.vaadin</groupId>
     <artifactId>vaadin-spring-parent</artifactId>
-    <version>2.1-SNAPSHOT</version>
+    <version>3.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>vaadin-spring-parent</name>

--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         
         <!-- These are typically overridden with BOMs -->
-        <vaadin.version>8.0.6</vaadin.version>
+        <vaadin.version>8.2-SNAPSHOT</vaadin.version>
         <spring.version>4.3.9.RELEASE</spring.version>
         <spring.security.version>4.2.3.RELEASE</spring.security.version>
         <spring.boot.version>1.4.7.RELEASE</spring.boot.version>

--- a/vaadin-spring-boot-starter/pom.xml
+++ b/vaadin-spring-boot-starter/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-spring-parent</artifactId>
-        <version>2.1-SNAPSHOT</version>
+        <version>3.0-SNAPSHOT</version>
     </parent>
 
     <name>vaadin-spring-boot-starter</name>

--- a/vaadin-spring-boot/pom.xml
+++ b/vaadin-spring-boot/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-spring-parent</artifactId>
-        <version>2.1-SNAPSHOT</version>
+        <version>3.0-SNAPSHOT</version>
     </parent>
 
     <name>vaadin-spring-boot</name>

--- a/vaadin-spring-boot/src/test/java/com/vaadin/spring/boot/internal/VaadinServletConfigurationUIPathTest.java
+++ b/vaadin-spring-boot/src/test/java/com/vaadin/spring/boot/internal/VaadinServletConfigurationUIPathTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2015-2017 The original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.vaadin.spring.boot.internal;
 
 import static org.junit.Assert.assertTrue;

--- a/vaadin-spring-boot/src/test/java/com/vaadin/spring/boot/internal/VaadinServletConfigurationUIPathTest.java
+++ b/vaadin-spring-boot/src/test/java/com/vaadin/spring/boot/internal/VaadinServletConfigurationUIPathTest.java
@@ -1,0 +1,114 @@
+package com.vaadin.spring.boot.internal;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.web.servlet.handler.SimpleUrlHandlerMapping;
+
+import com.vaadin.navigator.PushStateNavigation;
+import com.vaadin.spring.annotation.EnableVaadinNavigation;
+import com.vaadin.spring.annotation.SpringUI;
+import com.vaadin.spring.server.AbstractSpringUIProviderTest;
+import com.vaadin.spring.server.AbstractSpringUIProviderTest.DummyUI;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration
+@WebAppConfiguration
+// make sure the context is cleaned
+@DirtiesContext
+public class VaadinServletConfigurationUIPathTest {
+
+    @SpringUI
+    private static class Root extends DummyUI {
+    }
+
+    @SpringUI(path = "sub/*")
+    private static class Sub extends DummyUI {
+    }
+
+    @SpringUI(path = "wild/**")
+    private static class Wildcard extends DummyUI {
+    }
+
+    @SpringUI(path = "pushState")
+    @PushStateNavigation
+    private static class PushState extends DummyUI {
+    }
+
+    private static class MyVaadinServletConfiguration
+            extends VaadinServletConfiguration {
+    }
+
+    private static class MyVaadinServletConfigurationProperties
+            extends VaadinServletConfigurationProperties {
+    }
+
+    @Configuration
+    @EnableVaadinNavigation
+    static class Config extends AbstractSpringUIProviderTest.Config {
+        @Bean
+        public Root root() {
+            return new Root();
+        }
+
+        @Bean
+        public Sub sub() {
+            return new Sub();
+        }
+
+        @Bean
+        public Wildcard wildcard() {
+            return new Wildcard();
+        }
+
+        @Bean
+        public PushState pushState() {
+            return new PushState();
+        }
+
+        @Bean
+        public MyVaadinServletConfiguration myVaadinServletConfiguration() {
+            return new MyVaadinServletConfiguration();
+        }
+
+        @Bean
+        public MyVaadinServletConfigurationProperties myVaadinServletConfigurationProperties() {
+            return new MyVaadinServletConfigurationProperties();
+        }
+    }
+
+    @Autowired
+    VaadinServletConfiguration configuration;
+
+    @Test
+    public void testUIMappings() {
+        SimpleUrlHandlerMapping mapping = configuration
+                .vaadinUiForwardingHandlerMapping();
+
+        Set<String> keySet = new HashSet<>(mapping.getUrlMap().keySet());
+
+        Stream.of("/", "/sub", "/sub/*", "/wild", "/wild/**", "/pushState",
+                "/pushState/**").forEach(mappedPath -> {
+                    assertTrue("Expected mapping not found: " + mappedPath,
+                            keySet.remove(mappedPath));
+                });
+
+        assertTrue(
+                "Extra path mapped: "
+                        + keySet.stream().collect(Collectors.joining(", ")),
+                keySet.isEmpty());
+    }
+}

--- a/vaadin-spring-security/pom.xml
+++ b/vaadin-spring-security/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-spring-parent</artifactId>
-        <version>2.1-SNAPSHOT</version>
+        <version>3.0-SNAPSHOT</version>
     </parent>
 
     <name>vaadin-spring-security</name>

--- a/vaadin-spring/pom.xml
+++ b/vaadin-spring/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-spring-parent</artifactId>
-        <version>2.1-SNAPSHOT</version>
+        <version>3.0-SNAPSHOT</version>
     </parent>
 
     <name>vaadin-spring</name>

--- a/vaadin-spring/src/main/java/com/vaadin/spring/server/SpringUIProvider.java
+++ b/vaadin-spring/src/main/java/com/vaadin/spring/server/SpringUIProvider.java
@@ -157,8 +157,9 @@ public class SpringUIProvider extends UIProvider {
         }
 
         // Pass the path info to the UI through request
-        uiClassSelectionEvent.getRequest()
-                .setAttribute(ApplicationConstants.UI_ROOT_PATH, pathInfo);
+        uiClassSelectionEvent.getRequest().setAttribute(
+                ApplicationConstants.UI_ROOT_PATH,
+                (pathInfo.startsWith("/") ? "" : "/") + pathInfo);
 
         return ui;
     }

--- a/vaadin-spring/src/main/java/com/vaadin/spring/server/SpringUIProvider.java
+++ b/vaadin-spring/src/main/java/com/vaadin/spring/server/SpringUIProvider.java
@@ -190,14 +190,19 @@ public class SpringUIProvider extends UIProvider {
     }
 
     protected void mapPathToUI(String path, Class<? extends UI> uiClass) {
-        boolean pathEndsWithWildcard = path.endsWith("/*");
+        boolean pathEndsWithWildcard = false;
+
+        if (path.endsWith("/*")) {
+            path = path.substring(0, path.length() - 2);
+            pathEndsWithWildcard = true;
+        } else if (path.endsWith("/**")) {
+            path = path.substring(0, path.length() - 3);
+            pathEndsWithWildcard = true;
+        }
+
         boolean isWildcardPath = pathEndsWithWildcard
                 // UIs that use PushStateNavigation need to be wildcarded.
                 || uiClass.isAnnotationPresent(PushStateNavigation.class);
-
-        if (pathEndsWithWildcard) {
-            path = path.substring(0, path.length() - 2);
-        }
 
         if (isWildcardPath) {
             wildcardPathToUIMap.put(path, uiClass);

--- a/vaadin-spring/src/test/java/com/vaadin/spring/server/SpringUIProviderTestWithWildcardUIs.java
+++ b/vaadin-spring/src/test/java/com/vaadin/spring/server/SpringUIProviderTestWithWildcardUIs.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2015-2017 The original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.vaadin.spring.server;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.Test;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.web.WebAppConfiguration;
+
+import com.vaadin.navigator.PushStateNavigation;
+import com.vaadin.server.UIClassSelectionEvent;
+import com.vaadin.server.VaadinRequest;
+import com.vaadin.server.VaadinService;
+import com.vaadin.spring.annotation.EnableVaadinNavigation;
+import com.vaadin.spring.annotation.SpringUI;
+import com.vaadin.ui.UI;
+
+@ContextConfiguration
+@WebAppConfiguration
+public class SpringUIProviderTestWithWildcardUIs
+        extends AbstractSpringUIProviderTest {
+
+    @SpringUI
+    private static class Root extends DummyUI {
+    }
+
+    @SpringUI(path = "sub/*")
+    private static class Sub extends DummyUI {
+    }
+
+    @SpringUI(path = "wild/**")
+    private static class Wildcard extends DummyUI {
+    }
+
+    @SpringUI(path = "pushState")
+    @PushStateNavigation
+    private static class PushState extends DummyUI {
+    }
+
+    @Configuration
+    @EnableVaadinNavigation
+    static class Config extends AbstractSpringUIProviderTest.Config {
+        @Bean
+        public Root root() {
+            return new Root();
+        }
+
+        @Bean
+        public Sub sub() {
+            return new Sub();
+        }
+
+        @Bean
+        public Wildcard wildcard() {
+            return new Wildcard();
+        }
+
+        @Bean
+        public PushState pushState() {
+            return new PushState();
+        }
+    }
+
+    @Test
+    public void testRootUI() {
+        verifyUIFromPath(Root.class, "");
+        verifyUIFromPath(Root.class, "/");
+    }
+
+    @Test
+    public void testSubUI() {
+        verifyUIFromPath(Sub.class, "/sub");
+        verifyUIFromPath(Sub.class, "/sub/");
+        verifyUIFromPath(Sub.class, "/sub/foo");
+    }
+
+    @Test
+    public void testWildcardUI() {
+        verifyUIFromPath(Wildcard.class, "/wild");
+        verifyUIFromPath(Wildcard.class, "/wild/");
+        verifyUIFromPath(Wildcard.class, "/wild/foo");
+        verifyUIFromPath(Wildcard.class, "/wild/foo/bar");
+        verifyUIFromPath(Wildcard.class, "/wild/foo/bar/baz");
+    }
+
+    @Test
+    public void testPushStateUI() {
+        verifyUIFromPath(PushState.class, "/pushState");
+        verifyUIFromPath(PushState.class, "/pushState/");
+        verifyUIFromPath(PushState.class, "/pushState/foo");
+        verifyUIFromPath(PushState.class, "/pushState/foo/bar");
+        verifyUIFromPath(PushState.class, "/pushState/foo/bar/baz");
+    }
+
+    private void verifyUIFromPath(Class<? extends UI> cls, String path) {
+        VaadinRequest request = mockRequest();
+        when(request.getPathInfo()).thenReturn(path);
+        assertEquals(cls.getCanonicalName(),
+                getUiProvider().getUIClass(new UIClassSelectionEvent(request))
+                        .getCanonicalName());
+    }
+
+    private VaadinRequest mockRequest() {
+        VaadinRequest request = mock(VaadinRequest.class);
+        when(request.getService()).thenReturn(mock(VaadinService.class));
+        return request;
+    }
+}

--- a/vaadin-spring/src/test/java/com/vaadin/spring/server/SpringUIProviderTestWithWildcardUIs.java
+++ b/vaadin-spring/src/test/java/com/vaadin/spring/server/SpringUIProviderTestWithWildcardUIs.java
@@ -55,6 +55,11 @@ public class SpringUIProviderTestWithWildcardUIs
     private static class PushState extends DummyUI {
     }
 
+    @SpringUI(path = "pushState/sub")
+    @PushStateNavigation
+    private static class PushStateSub extends DummyUI {
+    }
+
     @Configuration
     @EnableVaadinNavigation
     static class Config extends AbstractSpringUIProviderTest.Config {
@@ -76,6 +81,11 @@ public class SpringUIProviderTestWithWildcardUIs
         @Bean
         public PushState pushState() {
             return new PushState();
+        }
+
+        @Bean
+        public PushStateSub pushStateSub() {
+            return new PushStateSub();
         }
     }
 
@@ -108,6 +118,15 @@ public class SpringUIProviderTestWithWildcardUIs
         verifyUIFromPath(PushState.class, "/pushState/foo");
         verifyUIFromPath(PushState.class, "/pushState/foo/bar");
         verifyUIFromPath(PushState.class, "/pushState/foo/bar/baz");
+    }
+
+    @Test
+    public void testPushStateSubUI() {
+        verifyUIFromPath(PushStateSub.class, "/pushState/sub");
+        verifyUIFromPath(PushStateSub.class, "/pushState/sub/");
+        verifyUIFromPath(PushStateSub.class, "/pushState/sub/foo");
+        verifyUIFromPath(PushStateSub.class, "/pushState/sub/foo/bar");
+        verifyUIFromPath(PushStateSub.class, "/pushState/sub/foo/bar/baz");
     }
 
     private void verifyUIFromPath(Class<? extends UI> cls, String path) {


### PR DESCRIPTION
Automatically use wildcard paths for UIs with PushStateNavigation annotation

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/spring/238)
<!-- Reviewable:end -->
