### PR TITLE
Fixes erroneous error message when using SpringUIProvider with PushSt…

### DIFF
--- a/vaadin-spring/src/main/java/com/vaadin/spring/server/SpringUIProvider.java
+++ b/vaadin-spring/src/main/java/com/vaadin/spring/server/SpringUIProvider.java
@@ -85,7 +85,7 @@ public class SpringUIProvider extends UIProvider {
                     "Spring WebApplicationContext not initialized for UI provider. Use e.g. ContextLoaderListener to initialize it.");
         }
         detectUIs();
-        if (pathToUIMap.isEmpty()) {
+        if (pathToUIMap.isEmpty() && wildcardPathToUIMap.isEmpty()) {
             logger.warn("Found no Vaadin UIs in the application context");
         }
     }


### PR DESCRIPTION
…ateNavigation or wildcard on the path.

The message "Found no Vaadin UIs in the application context" is logged even when UIs have been found. The current code only checks the pathToUIMap and should check the wildcardPathToUIMap  as well before logging this message.

The message will have a negative impact on users who may think they have incorrectly configured their applications when in fact that is not the case.

closes #254

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/spring/255)
<!-- Reviewable:end -->
