### PR TITLE
Avoid singleton component in test class

### DIFF
--- a/vaadin-spring-tests/test-spring-common/src/main/java/com/vaadin/flow/spring/test/FooNavigationTarget.java
+++ b/vaadin-spring-tests/test-spring-common/src/main/java/com/vaadin/flow/spring/test/FooNavigationTarget.java
@@ -15,12 +15,11 @@
  */
 package com.vaadin.flow.spring.test;
 
-import org.springframework.beans.factory.config.ConfigurableBeanFactory;
-import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
 
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.router.Route;
+import com.vaadin.flow.spring.annotation.VaadinSessionScope;
 
 /**
  * @author Vaadin Ltd
@@ -28,7 +27,7 @@ import com.vaadin.flow.router.Route;
  */
 @Route("foo")
 @Component
-@Scope(ConfigurableBeanFactory.SCOPE_SINGLETON)
+@VaadinSessionScope
 public class FooNavigationTarget extends Div {
 
 }


### PR DESCRIPTION
Use of a globally shared component instance will be broken after vaadin/flow#3797

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/spring/287)
<!-- Reviewable:end -->
