### PR TITLE
Only define spring-boot version.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,8 +39,7 @@
         
         <!-- These are typically overridden with BOMs -->
         <vaadin.version>1.0-SNAPSHOT</vaadin.version>
-	<spring.version>5.0.2.RELEASE</spring.version>
-        <spring-boot.version>2.0.0.RELEASE</spring-boot.version>
+        <spring-boot.version>2.0.2.RELEASE</spring-boot.version>
 
         <!-- Additional manifest fields -->
         <Vaadin-License-Title>Apache License 2.0</Vaadin-License-Title>

--- a/vaadin-spring-boot-starter/pom.xml
+++ b/vaadin-spring-boot-starter/pom.xml
@@ -40,13 +40,6 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-dependencies</artifactId>
-                <version>${spring-boot.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
                 <groupId>com.vaadin</groupId>
                 <artifactId>vaadin-bom</artifactId>
                 <type>pom</type>

--- a/vaadin-spring-tests/pom.xml
+++ b/vaadin-spring-tests/pom.xml
@@ -34,7 +34,6 @@
             concurrent running of test modules. -->
         <server.port>8888</server.port>
         <server.stop.port>8889</server.stop.port>
-        <spring-boot.version>2.0.0.RELEASE</spring-boot.version>
         <jetty.version>9.4.9.v20180320</jetty.version>
         <maven.failsafe.plugin.version>2.20</maven.failsafe.plugin.version>
         <driver.binary.downloader.maven.plugin.version>1.0.14

--- a/vaadin-spring-tests/test-spring-boot-scan/pom.xml
+++ b/vaadin-spring-tests/test-spring-boot-scan/pom.xml
@@ -16,14 +16,6 @@
 
     <dependencyManagement>
         <dependencies>
-            <dependency>
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-dependencies</artifactId>
-                <version>${spring-boot.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-
             <!-- Override selenium versions as spring versions are too new -->
             <dependency>
                 <groupId>org.seleniumhq.selenium</groupId>

--- a/vaadin-spring-tests/test-spring-boot/pom.xml
+++ b/vaadin-spring-tests/test-spring-boot/pom.xml
@@ -16,14 +16,6 @@
 
     <dependencyManagement>
         <dependencies>
-            <dependency>
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-dependencies</artifactId>
-                <version>${spring-boot.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-
             <!-- Override selenium versions as spring versions are too new -->
             <dependency>
                 <groupId>org.seleniumhq.selenium</groupId>

--- a/vaadin-spring-tests/test-spring-common/pom.xml
+++ b/vaadin-spring-tests/test-spring-common/pom.xml
@@ -31,7 +31,6 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-context</artifactId>
-            <version>5.0.2.RELEASE</version>
         </dependency>
 
         <dependency>

--- a/vaadin-spring-tests/test-spring-war/pom.xml
+++ b/vaadin-spring-tests/test-spring-war/pom.xml
@@ -16,15 +16,6 @@
 
     <dependencyManagement>
         <dependencies>
-            <dependency>
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-dependencies</artifactId>
-                <version>${spring-boot.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-
-
             <!-- Downgrade log4j as jetty doesn't support multi module -->
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>


### PR DESCRIPTION
Other versions should be used from the dependencies bom.
Clean-up of pom files as the relations changed after
'add-on' was moved from Flow repository.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/spring/311)
<!-- Reviewable:end -->
