### PR TITLE
Fix memory leak: Session BeanStore.class was unset from Session

### DIFF
--- a/vaadin-spring/src/main/java/com/vaadin/spring/internal/UIScopeImpl.java
+++ b/vaadin-spring/src/main/java/com/vaadin/spring/internal/UIScopeImpl.java
@@ -243,7 +243,7 @@ public class UIScopeImpl implements Scope, BeanFactoryPostProcessor {
 
         void destroy() {
             LOGGER.trace("Destroying [{}]", this);
-            session.setAttribute(BeanStore.class, null);
+            session.setAttribute(UIStore.class, null);
             session.getService().removeServiceDestroyListener(this);
             for (BeanStore beanStore : new HashSet<BeanStore>(
                     beanStoreMap.values())) {


### PR DESCRIPTION
Session BeanStore.class was unset from Session before Session clean up (see #292)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/spring/332)
<!-- Reviewable:end -->
