### PR TITLE
added hotfix for spring boot 2.0.4 compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
 
         <!-- These are typically overridden with BOMs -->
         <vaadin.flow.version>1.1-SNAPSHOT</vaadin.flow.version>
-        <spring-boot.version>2.0.2.RELEASE</spring-boot.version>
+        <spring-boot.version>2.0.4.RELEASE</spring-boot.version>
 
         <!-- Additional manifest fields -->
         <Vaadin-License-Title>Apache License 2.0</Vaadin-License-Title>

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/SpringBootAutoConfiguration.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/SpringBootAutoConfiguration.java
@@ -35,6 +35,7 @@ import org.springframework.web.servlet.DispatcherServlet;
 import org.springframework.web.socket.server.standard.ServerEndpointExporter;
 
 import com.vaadin.flow.server.Constants;
+import org.springframework.boot.autoconfigure.web.servlet.DispatcherServletRegistrationBean;
 
 /**
  * Spring boot auto-configuration class for Flow.
@@ -92,20 +93,20 @@ public class SpringBootAutoConfiguration {
     }
 
     /**
-     * Creates a {@link ServletRegistrationBean} instance for a dispatcher
+     * Creates a {@link DispatcherServletRegistrationBean} instance for a dispatcher
      * servlet in case Vaadin servlet is mapped to the root.
      * <p>
      * This is needed for correct servlet path (and path info) values available
      * in Vaadin servlet because it works via forwarding controller which is not
      * properly mapped without this registration.
      *
-     * @return a custom ServletRegistrationBean instance for dispatcher servlet
+     * @return a custom DispatcherServletRegistrationBean instance for dispatcher servlet
      */
     @Bean
     @Conditional(RootMappedCondition.class)
-    public ServletRegistrationBean<DispatcherServlet> dispatcherServletRegistration() {
+    public DispatcherServletRegistrationBean dispatcherServletRegistration() {
         DispatcherServlet servlet = context.getBean(DispatcherServlet.class);
-        ServletRegistrationBean<DispatcherServlet> registration = new ServletRegistrationBean<>(
+        DispatcherServletRegistrationBean registration = new DispatcherServletRegistrationBean(
                 servlet, "/*");
         registration.setName("dispatcher");
         return registration;


### PR DESCRIPTION
Added a quick workaround for 2.0.4 compatibility. With next maintenance release notes we'll need to mention that 2.0.4 is required.