### PR TITLE
Update dependencies to get rid of security alert

### DIFF
--- a/vaadin-spring-tests/pom.xml
+++ b/vaadin-spring-tests/pom.xml
@@ -44,6 +44,16 @@
         <maven.war.plugin.version>3.1.0</maven.war.plugin.version>
     </properties>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.security.oauth</groupId>
+                <artifactId>spring-security-oauth2</artifactId>
+                <version>2.2.3.RELEASE</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <!-- Project dependencies -->
         <dependency>

--- a/vaadin-spring-tests/test-spring-boot-contextpath/pom.xml
+++ b/vaadin-spring-tests/test-spring-boot-contextpath/pom.xml
@@ -85,7 +85,6 @@
         <dependency>
             <groupId>org.springframework.security.oauth</groupId>
             <artifactId>spring-security-oauth2</artifactId>
-            <version>2.2.1.RELEASE</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.springframework</groupId>

--- a/vaadin-spring-tests/test-spring-boot-scan/pom.xml
+++ b/vaadin-spring-tests/test-spring-boot-scan/pom.xml
@@ -86,7 +86,6 @@
         <dependency>
             <groupId>org.springframework.security.oauth</groupId>
             <artifactId>spring-security-oauth2</artifactId>
-            <version>2.2.1.RELEASE</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.springframework</groupId>

--- a/vaadin-spring-tests/test-spring-boot-undertow/pom.xml
+++ b/vaadin-spring-tests/test-spring-boot-undertow/pom.xml
@@ -91,7 +91,6 @@
         <dependency>
             <groupId>org.springframework.security.oauth</groupId>
             <artifactId>spring-security-oauth2</artifactId>
-            <version>2.2.1.RELEASE</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.springframework</groupId>

--- a/vaadin-spring-tests/test-spring-boot/pom.xml
+++ b/vaadin-spring-tests/test-spring-boot/pom.xml
@@ -74,7 +74,6 @@
         <dependency>
             <groupId>org.springframework.security.oauth</groupId>
             <artifactId>spring-security-oauth2</artifactId>
-            <version>2.2.1.RELEASE</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.springframework</groupId>

--- a/vaadin-spring-tests/test-spring-war/pom.xml
+++ b/vaadin-spring-tests/test-spring-war/pom.xml
@@ -68,7 +68,6 @@
         <dependency>
             <groupId>org.springframework.security.oauth</groupId>
             <artifactId>spring-security-oauth2</artifactId>
-            <version>2.2.1.RELEASE</version>
         </dependency>
 
         <dependency>

--- a/vaadin-spring-tests/test-spring/pom.xml
+++ b/vaadin-spring-tests/test-spring/pom.xml
@@ -39,7 +39,6 @@
         <dependency>
             <groupId>org.springframework.security.oauth</groupId>
             <artifactId>spring-security-oauth2</artifactId>
-            <version>2.2.1.RELEASE</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.springframework</groupId>


### PR DESCRIPTION
Move spring-security-oauth2 dependency to dependency management in the  parent project, as it is used in all the submodules.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/spring/364)
<!-- Reviewable:end -->
