### PR TITLE
Remove the Line checkings from checkStyle

### DIFF
--- a/checkstyle/vaadin-checkstyle.xml
+++ b/checkstyle/vaadin-checkstyle.xml
@@ -59,10 +59,6 @@
     <module name="NewlineAtEndOfFile">
         <property name="severity" value="warning" />
     </module>
-    <module name="RegexpMultiline">
-        <property name="message" value="File contains carriage return (Windows newlines)" />
-        <property name="format" value="\r"/>
-    </module>
     
 
     <!-- Checks that property files contain the same keys. -->


### PR DESCRIPTION
This checking is not used for `framework` project or the others, but it blocks the build for Windows users.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/spring/391)
<!-- Reviewable:end -->
