### PR TITLE
Fix for "Misleading Error Message when autowiring beans" in Issue #407

### DIFF
--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/SpringInstantiator.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/SpringInstantiator.java
@@ -83,8 +83,11 @@ public class SpringInstantiator extends DefaultInstantiator {
     public <T> T getOrCreate(Class<T> type) {
         if (context.getBeanNamesForType(type).length == 1) {
             return context.getBean(type);
+        } else if (context.getBeanNamesForType(type).length > 1) {
+            throw new IllegalStateException("Unable to autowire existing beans, there are more " +
+                    "than 1 autowiring candidates");
         }
-
+        // If there is no bean, try to instantiate one
         return context.getAutowireCapableBeanFactory().createBean(type);
     }
 }

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/SpringInstantiator.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/SpringInstantiator.java
@@ -19,6 +19,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Stream;
 
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.BeanInstantiationException;
 import org.springframework.context.ApplicationContext;
 
 import com.vaadin.flow.di.DefaultInstantiator;
@@ -32,7 +33,6 @@ import com.vaadin.flow.server.VaadinServiceInitListener;
  * registered. This implementation uses Spring beans.
  *
  * @author Vaadin Ltd
- *
  */
 public class SpringInstantiator extends DefaultInstantiator {
 
@@ -42,13 +42,11 @@ public class SpringInstantiator extends DefaultInstantiator {
     /**
      * Creates a new spring instantiator instance.
      *
-     * @param service
-     *            the service to use
-     * @param context
-     *            the application context
+     * @param service the service to use
+     * @param context the application context
      */
     public SpringInstantiator(VaadinService service,
-            ApplicationContext context) {
+                              ApplicationContext context) {
         super(service);
         this.context = context;
 
@@ -72,22 +70,44 @@ public class SpringInstantiator extends DefaultInstantiator {
             if (loggingEnabled.compareAndSet(true, false)) {
                 LoggerFactory.getLogger(SpringInstantiator.class.getName())
                         .info("The number of beans implementing '{}' is {}. Cannot use Spring beans for I18N, "
-                                + "falling back to the default behavior",
+                                        + "falling back to the default behavior",
                                 I18NProvider.class.getSimpleName(), beansCount);
             }
             return super.getI18NProvider();
         }
     }
 
+    /**
+     * Hands over an existing bean or tries to instantiate one with the following rules:
+     * <ul>
+     * <li>
+     * If exactly one bean is present in the context, it returns this bean.
+     * </li>
+     * <li>
+     * If no bean is present, it tries to instantiate one.
+     * </li>
+     * <li>
+     * If more than one bean is present, it tries to instantiate one but in case of a
+     * Bean instantiation exception this exception is catched and rethrown with a hint.
+     * Reason for this is, that users may expect it to "use" a bean but have multiple in the context.
+     * So the hint helps them find the problem.
+     * </li>
+     * </ul>
+     */
     @Override
     public <T> T getOrCreate(Class<T> type) {
         if (context.getBeanNamesForType(type).length == 1) {
             return context.getBean(type);
         } else if (context.getBeanNamesForType(type).length > 1) {
-            throw new IllegalStateException("Unable to autowire existing beans, there are more " +
-                    "than 1 autowiring candidates");
+            try {
+                return context.getAutowireCapableBeanFactory().createBean(type);
+            } catch (BeanInstantiationException e) {
+                throw new BeanInstantiationException(e.getBeanClass(), e.getMessage() +
+                        " [HINT] this could be caused by more than one suitable beans for autowiring in the context.");
+            }
+        } else {
+            // If there is no bean, try to instantiate one
+            return context.getAutowireCapableBeanFactory().createBean(type);
         }
-        // If there is no bean, try to instantiate one
-        return context.getAutowireCapableBeanFactory().createBean(type);
     }
 }

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/SpringInstantiator.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/SpringInstantiator.java
@@ -102,8 +102,9 @@ public class SpringInstantiator extends DefaultInstantiator {
             try {
                 return context.getAutowireCapableBeanFactory().createBean(type);
             } catch (BeanInstantiationException e) {
-                throw new BeanInstantiationException(e.getBeanClass(), e.getMessage() +
-                        " [HINT] this could be caused by more than one suitable beans for autowiring in the context.");
+                throw new BeanInstantiationException(e.getBeanClass(),
+                        "[HINT] This could be caused by more than one suitable beans for autowiring in the context.",
+                        e);
             }
         } else {
             // If there is no bean, try to instantiate one

--- a/vaadin-spring/src/test/java/com/vaadin/flow/spring/instantiator/SpringInstantiatorTest.java
+++ b/vaadin-spring/src/test/java/com/vaadin/flow/spring/instantiator/SpringInstantiatorTest.java
@@ -26,6 +26,7 @@ import javax.servlet.ServletConfig;
 import javax.servlet.ServletContext;
 import javax.servlet.ServletException;
 
+import com.vaadin.flow.spring.SpringInstantiator;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -173,5 +174,14 @@ public class SpringInstantiatorTest {
     public static Instantiator getInstantiator(ApplicationContext context)
             throws ServletException {
         return getService(context, null).getInstantiator();
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void getOrCreateBean_multipleBeansGiven_throwsException() {
+        ApplicationContext context = Mockito.mock(ApplicationContext.class);
+        Mockito.when(context.getBeanNamesForType(String.class)).thenReturn(new String[]{"one", "two"});
+        SpringInstantiator instantiator = new SpringInstantiator(null, context);
+
+        instantiator.getOrCreate(String.class);
     }
 }

--- a/vaadin-spring/src/test/java/com/vaadin/flow/spring/instantiator/SpringInstantiatorTest.java
+++ b/vaadin-spring/src/test/java/com/vaadin/flow/spring/instantiator/SpringInstantiatorTest.java
@@ -27,10 +27,12 @@ import javax.servlet.ServletContext;
 import javax.servlet.ServletException;
 
 import com.vaadin.flow.spring.SpringInstantiator;
+import org.hamcrest.Matchers;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
+import org.springframework.beans.BeanInstantiationException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.context.ApplicationContext;
@@ -176,12 +178,61 @@ public class SpringInstantiatorTest {
         return getService(context, null).getInstantiator();
     }
 
-    @Test(expected = IllegalStateException.class)
-    public void getOrCreateBean_multipleBeansGiven_throwsException() {
-        ApplicationContext context = Mockito.mock(ApplicationContext.class);
-        Mockito.when(context.getBeanNamesForType(String.class)).thenReturn(new String[]{"one", "two"});
+    @Test
+    public void getOrCreateBean_noBeansGivenCannotInstantiate_throwsExceptionWithoutHint() {
+        ApplicationContext context = Mockito.mock(ApplicationContext.class, Mockito.RETURNS_DEEP_STUBS);
+        Mockito.when(context.getBeanNamesForType(Number.class)).thenReturn(new String[]{});
+        Mockito.when(context.getAutowireCapableBeanFactory().createBean(Number.class)).thenThrow(new BeanInstantiationException(Number.class, "This is an abstract class"));
         SpringInstantiator instantiator = new SpringInstantiator(null, context);
 
-        instantiator.getOrCreate(String.class);
+        try {
+            instantiator.getOrCreate(Number.class);
+        } catch (BeanInstantiationException e) {
+            Assert.assertNotNull(e.getMessage());
+            Assert.assertFalse(e.getMessage().contains("[HINT]"));
+            return;
+        }
+        Assert.fail();
+    }
+
+    @Test
+    public void getOrCreateBean_multipleBeansGivenCannotInstantiate_throwsExceptionWithHint() {
+        ApplicationContext context = Mockito.mock(ApplicationContext.class, Mockito.RETURNS_DEEP_STUBS);
+        Mockito.when(context.getBeanNamesForType(Number.class)).thenReturn(new String[]{"one", "two"});
+        Mockito.when(context.getAutowireCapableBeanFactory().createBean(Number.class)).thenThrow(new BeanInstantiationException(Number.class, "This is an abstract class"));
+        SpringInstantiator instantiator = new SpringInstantiator(null, context);
+
+        try {
+            instantiator.getOrCreate(Number.class);
+        } catch (BeanInstantiationException e) {
+            Assert.assertNotNull(e.getMessage());
+            Assert.assertTrue(e.getMessage().contains("[HINT]"));
+            return;
+        }
+        Assert.fail();
+    }
+
+    @Test
+    public void getOrCreateBean_oneBeanGiven_noException() {
+        ApplicationContext context = Mockito.mock(ApplicationContext.class);
+        Mockito.when(context.getBeanNamesForType(Number.class)).thenReturn(new String[]{"one"});
+        Mockito.when(context.getBean(Number.class)).thenReturn(0);
+        SpringInstantiator instantiator = new SpringInstantiator(null, context);
+
+        Number bean = instantiator.getOrCreate(Number.class);
+
+        Assert.assertEquals(0, bean);
+    }
+
+    @Test
+    public void getOrCreateBean_multipleBeansGivenButCanInstantiate_noException() {
+        ApplicationContext context = Mockito.mock(ApplicationContext.class, Mockito.RETURNS_DEEP_STUBS);
+        Mockito.when(context.getBeanNamesForType(String.class)).thenReturn(new String[]{"one", "two"});
+        Mockito.when(context.getAutowireCapableBeanFactory().createBean(String.class)).thenReturn("string");
+        SpringInstantiator instantiator = new SpringInstantiator(null, context);
+
+        String bean = instantiator.getOrCreate(String.class);
+
+        Assert.assertEquals("string", bean);
     }
 }


### PR DESCRIPTION
When using SpringBeans with Vaadin for autowiring, there is a misleading error message when one has 2 or more suitable Beans in the Context.
The SpringInstantiator's getOrCreate Method autowires the bean only when there is exactly one bean in the scope or otherwise it tries to instantiate the given interface, which leads to the message

`Caused by: org.springframework.beans.BeanInstantiationException: Failed to instantiate [this.is.my.Interface]: Specified class is an interface`

This PR fixes this and shows a separate exception when there are more than 1 beans in the context, and does not try to instantiate a new bean instance.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/spring/408)
<!-- Reviewable:end -->
