### PR TITLE
Introduce VaadinWebsocketEndpointExporter to fix WebSocket issue with Spring Boot

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         
         <!-- These are typically overridden with BOMs -->
-        <vaadin.version>8.9-SNAPSHOT</vaadin.version>
+        <vaadin.version>8.8.0</vaadin.version>
         <spring.version>4.3.9.RELEASE</spring.version>
         <spring.security.version>4.2.3.RELEASE</spring.security.version>
         <spring.boot.version>1.4.7.RELEASE</spring.boot.version>

--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         
         <!-- These are typically overridden with BOMs -->
-        <vaadin.version>8.2.0</vaadin.version>
+        <vaadin.version>8.9-SNAPSHOT</vaadin.version>
         <spring.version>4.3.9.RELEASE</spring.version>
         <spring.security.version>4.2.3.RELEASE</spring.security.version>
         <spring.boot.version>1.4.7.RELEASE</spring.boot.version>

--- a/vaadin-spring-boot/pom.xml
+++ b/vaadin-spring-boot/pom.xml
@@ -36,10 +36,21 @@
             <artifactId>spring-boot-autoconfigure</artifactId>
             <version>${spring.boot.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+            <version>${spring.boot.version}</version>
+            <scope>provided</scope>
+        </dependency>        
         <!-- ServletForwardingController used for interoperation with Spring MVC -->
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-webmvc</artifactId>
+            <version>${spring.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-websocket</artifactId>
             <version>${spring.version}</version>
         </dependency>
         <!-- @ConfigurationProperties annotation processing (metadata for IDEs) -->

--- a/vaadin-spring-boot/src/main/java/com/vaadin/spring/boot/VaadinAutoConfiguration.java
+++ b/vaadin-spring-boot/src/main/java/com/vaadin/spring/boot/VaadinAutoConfiguration.java
@@ -22,6 +22,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.socket.server.standard.ServerEndpointExporter;
 
 import com.vaadin.spring.annotation.EnableVaadin;
 import com.vaadin.spring.annotation.SpringUI;
@@ -97,4 +98,13 @@ public class VaadinAutoConfiguration {
         }
     }
 
+    /**
+     * Deploys JSR-356 websocket endpoints when Atmosphere is available.
+     *
+     * @return the server endpoint exporter which does the actual work.
+     */
+    @Bean
+    public ServerEndpointExporter websocketEndpointDeployer() {
+        return new VaadinWebsocketEndpointExporter();
+    }    
 }

--- a/vaadin-spring-boot/src/main/java/com/vaadin/spring/boot/VaadinWebsocketEndpointExporter.java
+++ b/vaadin-spring-boot/src/main/java/com/vaadin/spring/boot/VaadinWebsocketEndpointExporter.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2015-2017 The original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.vaadin.spring.boot;
+
+
+import org.springframework.web.socket.server.standard.ServerEndpointExporter;
+
+import com.vaadin.server.communication.JSR356WebsocketInitializer;
+
+
+/**
+ * Handles registration of JSR-356 websocket endpoints when the Spring Boot
+ * application is run in an embedded container. Also triggered when running in a
+ * real server but is not necessary in this scenario as
+ * JSR356WebsocketInitializer is triggered by the servlet container.
+ */
+public class VaadinWebsocketEndpointExporter extends ServerEndpointExporter {
+
+    @Override
+    protected void registerEndpoints() {
+        super.registerEndpoints();
+        if (!JSR356WebsocketInitializer.isAtmosphereAvailable()) {
+            return;
+        }
+
+        if (getServerContainer() == null) {
+            // ServerContainer (i.e. the websocket server provided by Jetty,
+            // Tomcat etc) can be null at this point when running in a real
+            // server (as opposed to embedded). At least Jetty uses a
+            // ServletContainerInitializer to initialize its websocket support
+            // and that one might or might not have been run before this code.
+            // Need to bail out and let JSR356WebsocketInitializer handle it
+            // through its listener when the websocket support is definitely
+            // available.
+            //
+            // This feels like a Spring Boot bug.
+            return;
+        }
+
+        new JSR356WebsocketInitializer().init(getServletContext());
+    }
+
+    @Override
+    public void afterPropertiesSet() {
+        // avoid call super method which may throw IllegalStateException
+    }
+
+}


### PR DESCRIPTION
Fixes vaadin/framework#10922
This is the second part of the fix of issue https://github.com/vaadin/framework/issues/10922

The fix is depending on Vaadin 8.8.0, which has the first part of the fix (see: https://github.com/vaadin/framework/pull/11551 )

This modification is analogous to one we have already made for Flow Spring add-on

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/spring/437)
<!-- Reviewable:end -->
