### PR TITLE
Fix the war test poms.

### DIFF
--- a/vaadin-spring-tests/test-spring-war/pom.xml
+++ b/vaadin-spring-tests/test-spring-war/pom.xml
@@ -128,7 +128,6 @@
                 <version>${vaadin.flow.version}</version>
                 <!-- Configure the output folder so that spring-boot-maven-plugin gets the generated resources -->
                 <configuration>
-                    <webpackOutputDirectory>${project.build.outputDirectory}/META-INF/resources</webpackOutputDirectory>
                     <productionMode>true</productionMode>
                 </configuration>
                 <executions>

--- a/vaadin-spring-tests/test-spring/pom.xml
+++ b/vaadin-spring-tests/test-spring/pom.xml
@@ -84,7 +84,6 @@
                 <version>${vaadin.flow.version}</version>
                 <!-- Configure the output folder so that spring-boot-maven-plugin gets the generated resources -->
                 <configuration>
-                    <webpackOutputDirectory>${project.build.outputDirectory}/META-INF/resources</webpackOutputDirectory>
                     <productionMode>true</productionMode>
                 </configuration>
                 <executions>


### PR DESCRIPTION
Now when we read things from the classpath the war configuration is faulty and moves things to an unexpected place.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/spring/449)
<!-- Reviewable:end -->
