### PR TITLE
Make it possible to add blacklisted packages

### DIFF
--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinConfigurationProperties.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinConfigurationProperties.java
@@ -15,6 +15,10 @@
  */
 package com.vaadin.flow.spring;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 /**
@@ -37,6 +41,11 @@ public class VaadinConfigurationProperties {
      * Whether asynchronous operations are supported.
      */
     private boolean asyncSupported = true;
+
+    /**
+     * Custom package blacklist that should be skipped in scanning.
+     */
+    private List<String> blacklistedPackages  = new ArrayList<>();
 
     /**
      * Gets the url mapping for the Vaadin servlet.
@@ -76,4 +85,22 @@ public class VaadinConfigurationProperties {
         this.asyncSupported = asyncSupported;
     }
 
+    /**
+     * Get a list of packages that are blacklisted for class scanning.
+     *
+     * @return package blacklist
+     */
+    public List<String> getBlacklistedPackages() {
+        return Collections.unmodifiableList(blacklistedPackages);
+    }
+
+    /**
+     * Set list of packages to ignore for class scanning.
+     *
+     * @param blacklistedPackages
+     *         list of packages to ignore
+     */
+    public void setBlacklistedPackages(List<String> blacklistedPackages) {
+        this.blacklistedPackages = new ArrayList<>(blacklistedPackages);
+    }
 }

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinServletContextInitializer.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinServletContextInitializer.java
@@ -323,7 +323,7 @@ public class VaadinServletContextInitializer
                 .getProperty("vaadin.blacklisted-packages");
         List<String> blacklist;
         if (property == null) {
-            blacklist = Collections.EMPTY_LIST;
+            blacklist = Collections.emptyList();
         } else {
             blacklist = Arrays.stream(property.split(",")).map(String::trim)
                     .collect(Collectors.toList());

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinServletContextInitializer.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinServletContextInitializer.java
@@ -24,6 +24,7 @@ import javax.servlet.ServletException;
 import java.io.IOException;
 import java.lang.annotation.Annotation;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Enumeration;
@@ -318,7 +319,15 @@ public class VaadinServletContextInitializer
      */
     public VaadinServletContextInitializer(ApplicationContext context) {
         appContext = context;
-        customLoader = new CustomResourceLoader(appContext);
+        String property = appContext.getEnvironment()
+                .getProperty("blacklisted.packages");
+        List<String> blacklist;
+        if (property == null) {
+            blacklist = Collections.EMPTY_LIST;
+        } else {
+            blacklist = Arrays.asList(property.split(","));
+        }
+        customLoader = new CustomResourceLoader(appContext, blacklist);
     }
 
     @Override
@@ -416,10 +425,6 @@ public class VaadinServletContextInitializer
         return getDefaultPackages();
     }
 
-    private Collection<String> getCustomElementPackages() {
-        return getDefaultPackages();
-    }
-
     private Collection<String> getVerifiableAnnotationPackages() {
         return getDefaultPackages();
     }
@@ -481,8 +486,9 @@ public class VaadinServletContextInitializer
                         "org/springframework", "org/webjars/bowergithub",
                         "org/yaml").collect(Collectors.toList());
 
-        public CustomResourceLoader(ResourceLoader resourceLoader) {
+        public CustomResourceLoader(ResourceLoader resourceLoader, List<String> addedBlacklist) {
             super(resourceLoader);
+            blackListed.addAll(addedBlacklist);
         }
 
         /**

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinServletContextInitializer.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinServletContextInitializer.java
@@ -320,12 +320,13 @@ public class VaadinServletContextInitializer
     public VaadinServletContextInitializer(ApplicationContext context) {
         appContext = context;
         String property = appContext.getEnvironment()
-                .getProperty("blacklisted.packages");
+                .getProperty("vaadin.blacklisted-packages");
         List<String> blacklist;
         if (property == null) {
             blacklist = Collections.EMPTY_LIST;
         } else {
-            blacklist = Arrays.asList(property.split(","));
+            blacklist = Arrays.stream(property.split(",")).map(String::trim)
+                    .collect(Collectors.toList());
         }
         customLoader = new CustomResourceLoader(appContext, blacklist);
     }


### PR DESCRIPTION
Environment variables can now be used to
add blacklisted packages for scanning.

Documented in vaadin/flow-and-components-documentation#643

Fixes vaadin/flow#5960 through manual optimization

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/spring/458)
<!-- Reviewable:end -->
