### PR TITLE
Set compatibilityMode to false explicitly in test service 

### DIFF
--- a/vaadin-spring-tests/test-spring-boot-contextpath/pom-bower-mode.xml
+++ b/vaadin-spring-tests/test-spring-boot-contextpath/pom-bower-mode.xml
@@ -29,6 +29,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>flow-server-compatibility-mode</artifactId>
+            <version>${vaadin.flow.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
 

--- a/vaadin-spring-tests/test-spring-boot-scan/pom-bower-mode.xml
+++ b/vaadin-spring-tests/test-spring-boot-scan/pom-bower-mode.xml
@@ -30,6 +30,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>flow-server-compatibility-mode</artifactId>
+            <version>${vaadin.flow.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
 

--- a/vaadin-spring-tests/test-spring-boot-undertow/pom-bower-mode.xml
+++ b/vaadin-spring-tests/test-spring-boot-undertow/pom-bower-mode.xml
@@ -40,6 +40,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>flow-server-compatibility-mode</artifactId>
+            <version>${vaadin.flow.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
       <exclusions>

--- a/vaadin-spring-tests/test-spring-boot/pom-bower-mode.xml
+++ b/vaadin-spring-tests/test-spring-boot/pom-bower-mode.xml
@@ -28,6 +28,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>flow-server-compatibility-mode</artifactId>
+            <version>${vaadin.flow.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
 

--- a/vaadin-spring-tests/test-spring-war/pom-bower-mode.xml
+++ b/vaadin-spring-tests/test-spring-war/pom-bower-mode.xml
@@ -51,6 +51,12 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>flow-server-compatibility-mode</artifactId>
+            <version>${vaadin.flow.version}</version>
+        </dependency>
+
         <!-- Spring -->
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/vaadin-spring-tests/test-spring-white-list/pom.xml
+++ b/vaadin-spring-tests/test-spring-white-list/pom.xml
@@ -113,7 +113,7 @@
                 <artifactId>spring-boot-maven-plugin</artifactId>
                 <version>${spring-boot.version}</version>
                 <configuration>
-                    <maxAttempts>30</maxAttempts>
+                    <maxAttempts>100</maxAttempts>
                     <wait>2500</wait>
                 </configuration>
                 <executions>

--- a/vaadin-spring-tests/test-spring/pom-bower-mode.xml
+++ b/vaadin-spring-tests/test-spring/pom-bower-mode.xml
@@ -15,7 +15,6 @@
     </properties>
 
     <dependencies>
-
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>vaadin-spring</artifactId>
@@ -34,6 +33,12 @@
                     <artifactId>spring-beans</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>flow-server-compatibility-mode</artifactId>
+            <version>${vaadin.flow.version}</version>
         </dependency>
 
         <dependency>

--- a/vaadin-spring/src/test/java/com/vaadin/flow/spring/SpringClassesSerializableTest.java
+++ b/vaadin-spring/src/test/java/com/vaadin/flow/spring/SpringClassesSerializableTest.java
@@ -23,6 +23,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import com.vaadin.flow.server.Constants;
 import com.vaadin.flow.server.DefaultDeploymentConfiguration;
 import com.vaadin.flow.server.VaadinService;
 import com.vaadin.flow.server.VaadinServlet;
@@ -119,9 +120,12 @@ public class SpringClassesSerializableTest extends ClassesSerializableTest {
     }
 
     private TestBeanStore createStore() {
+        final Properties initParameters = new Properties();
+        initParameters.setProperty(Constants.SERVLET_PARAMETER_COMPATIBILITY_MODE,
+                Boolean.FALSE.toString());
         VaadinService service = new VaadinServletService(new VaadinServlet(),
                 new DefaultDeploymentConfiguration(getClass(),
-                        new Properties()));
+                        initParameters));
         VaadinSession session = new TestSession(service);
 
         TestBeanStore store = new TestBeanStore(session);

--- a/vaadin-spring/src/test/java/com/vaadin/flow/spring/i18n/I18NProviderInstantiationTest.java
+++ b/vaadin-spring/src/test/java/com/vaadin/flow/spring/i18n/I18NProviderInstantiationTest.java
@@ -90,6 +90,8 @@ public class I18NProviderInstantiationTest {
         Properties properties = new Properties();
         properties.put(Constants.I18N_PROVIDER,
                 DefaultI18NTestProvider.class.getName());
+        properties.setProperty(Constants.SERVLET_PARAMETER_COMPATIBILITY_MODE,
+                Boolean.FALSE.toString());
         return SpringInstantiatorTest.getService(context, properties)
                 .getInstantiator();
     }

--- a/vaadin-spring/src/test/java/com/vaadin/flow/spring/instantiator/SpringInstantiatorTest.java
+++ b/vaadin-spring/src/test/java/com/vaadin/flow/spring/instantiator/SpringInstantiatorTest.java
@@ -45,6 +45,7 @@ import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.di.Instantiator;
 import com.vaadin.flow.function.DeploymentConfiguration;
 import com.vaadin.flow.i18n.I18NProvider;
+import com.vaadin.flow.server.Constants;
 import com.vaadin.flow.server.ServiceInitEvent;
 import com.vaadin.flow.server.VaadinServiceInitListener;
 import com.vaadin.flow.server.VaadinServletService;
@@ -187,7 +188,10 @@ public class SpringInstantiatorTest {
 
     public static Instantiator getInstantiator(ApplicationContext context)
             throws ServletException {
-        return getService(context, null).getInstantiator();
+        Properties initParameters = new Properties();
+        initParameters.put(Constants.SERVLET_PARAMETER_COMPATIBILITY_MODE,
+                Boolean.FALSE.toString());
+        return getService(context, initParameters).getInstantiator();
     }
 
     @Test

--- a/vaadin-spring/src/test/java/com/vaadin/flow/spring/scopes/AbstractScopeTest.java
+++ b/vaadin-spring/src/test/java/com/vaadin/flow/spring/scopes/AbstractScopeTest.java
@@ -25,6 +25,7 @@ import org.mockito.Mockito;
 import org.springframework.beans.factory.ObjectFactory;
 import org.springframework.beans.factory.config.Scope;
 
+import com.vaadin.flow.server.Constants;
 import com.vaadin.flow.server.DefaultDeploymentConfiguration;
 import com.vaadin.flow.server.VaadinService;
 import com.vaadin.flow.server.VaadinSession;
@@ -136,9 +137,14 @@ public abstract class AbstractScopeTest {
         doCallRealMethod().when(session).getService();
 
         when(session.getState()).thenReturn(VaadinSessionState.OPEN);
+
+        final Properties initParameters = new Properties();
+        initParameters.setProperty(Constants.SERVLET_PARAMETER_COMPATIBILITY_MODE,
+                Boolean.FALSE.toString());
         when(session.getConfiguration())
                 .thenReturn(new DefaultDeploymentConfiguration(getClass(),
-                        new Properties()));
+                        initParameters));
+
         VaadinSession.setCurrent(session);
         when(session.hasLock()).thenReturn(true);
 

--- a/vaadin-spring/src/test/java/com/vaadin/flow/spring/scopes/VaadinUIScopeTest.java
+++ b/vaadin-spring/src/test/java/com/vaadin/flow/spring/scopes/VaadinUIScopeTest.java
@@ -33,6 +33,7 @@ import org.springframework.beans.factory.config.Scope;
 import com.vaadin.flow.component.ComponentUtil;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.router.Router;
+import com.vaadin.flow.server.Constants;
 import com.vaadin.flow.server.DefaultDeploymentConfiguration;
 import com.vaadin.flow.server.VaadinContext;
 import com.vaadin.flow.server.VaadinService;
@@ -197,9 +198,14 @@ public class VaadinUIScopeTest extends AbstractScopeTest {
         Router router = mock(Router.class);
         VaadinService service = session.getService();
         when(service.getRouter()).thenReturn(router);
+
+        Properties initParameters = new Properties();
+        initParameters.put(Constants.SERVLET_PARAMETER_COMPATIBILITY_MODE,
+                Boolean.FALSE.toString());
         when(service.getDeploymentConfiguration())
                 .thenReturn(new DefaultDeploymentConfiguration(getClass(),
-                        new Properties()));
+                        initParameters));
+
         when(service.getMainDivId(Mockito.any(), Mockito.any()))
                 .thenReturn(" - ");
 

--- a/vaadin-spring/src/test/java/com/vaadin/flow/spring/service/SpringVaadinServletServiceTest.java
+++ b/vaadin-spring/src/test/java/com/vaadin/flow/spring/service/SpringVaadinServletServiceTest.java
@@ -32,6 +32,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import com.vaadin.flow.di.Instantiator;
+import com.vaadin.flow.server.Constants;
 import com.vaadin.flow.server.VaadinService;
 import com.vaadin.flow.server.VaadinServiceInitListener;
 import com.vaadin.flow.spring.instantiator.SpringInstantiatorTest;
@@ -43,6 +44,13 @@ public class SpringVaadinServletServiceTest {
     private static final String FOO = "foo";
 
     private static final String BAR = "bar";
+
+    private static final Properties BASE_PROPERTIES = new Properties();
+
+    {
+        BASE_PROPERTIES.put(Constants.SERVLET_PARAMETER_COMPATIBILITY_MODE,
+                Boolean.FALSE.toString());
+    }
 
     @Autowired
     private ApplicationContext context;
@@ -93,7 +101,7 @@ public class SpringVaadinServletServiceTest {
     @Test
     public void getInstantiator_springManagedBean_instantiatorBeanReturned()
             throws ServletException {
-        Properties properties = new Properties();
+        Properties properties = new Properties(BASE_PROPERTIES);
         properties.setProperty(FOO, Boolean.TRUE.toString());
         VaadinService service = SpringInstantiatorTest.getService(context,
                 properties);
@@ -106,7 +114,7 @@ public class SpringVaadinServletServiceTest {
     @Test
     public void getInstantiator_javaSPIClass_instantiatorPojoReturned()
             throws ServletException {
-        Properties properties = new Properties();
+        Properties properties = new Properties(BASE_PROPERTIES);
         properties.setProperty(FOO, Boolean.FALSE.toString());
         VaadinService service = SpringInstantiatorTest.getService(context,
                 properties);
@@ -119,7 +127,7 @@ public class SpringVaadinServletServiceTest {
     @Test(expected = ServletException.class)
     public void getInstantiator_nonUnique_exceptionIsThrown()
             throws ServletException {
-        Properties properties = new Properties();
+        Properties properties = new Properties(BASE_PROPERTIES);
         properties.setProperty(FOO, BAR);
         SpringInstantiatorTest.getService(context, properties);
     }


### PR DESCRIPTION
Due to https://github.com/vaadin/flow/pull/6122, `DefaultDeploymentConfiguration` throws if the mode of operation (npm/compatibility) cannot be determined. Updated tests to set `compatibilityMode` to `false` explicitly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/spring/470)
<!-- Reviewable:end -->
