### PR TITLE
Activate compatibility mode by JVM property

### DIFF
--- a/vaadin-spring-tests/pom.xml
+++ b/vaadin-spring-tests/pom.xml
@@ -346,9 +346,17 @@
                     <name>bowerMode</name>
                 </property>
             </activation>
-            <properties>
-                <vaadin.compatibilityMode>true</vaadin.compatibilityMode>
-            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-maven-plugin</artifactId>
+                        <configuration>
+                            <jvmArguments>-Dvaadin.compatibilityMode</jvmArguments>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
             <modules>
                 <module>test-spring-common</module>
 


### PR DESCRIPTION
`vaadin.compatibilityMode` was only set as a Maven property in the previous PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/spring/474)
<!-- Reviewable:end -->
