### PR TITLE
Fix flow#6404

### DIFF
--- a/vaadin-spring-tests/test-spring-boot-only-prepare/pom.xml
+++ b/vaadin-spring-tests/test-spring-boot-only-prepare/pom.xml
@@ -69,7 +69,7 @@
                     <artifactId>spring-boot-maven-plugin</artifactId>
                     <version>${spring-boot.version}</version>
                     <configuration>
-                        <maxAttempts>100</maxAttempts>
+                        <maxAttempts>30</maxAttempts>
                         <wait>2500</wait>
                     </configuration>
                 </plugin>

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinServletContextInitializer.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinServletContextInitializer.java
@@ -442,6 +442,7 @@ public class VaadinServletContextInitializer
 
         } else {
             customWhitelist = Arrays.stream(whitelistProperty.split(","))
+                    .map(s -> s.replace('/', '.'))
                     .map(String::trim).collect(Collectors.toList());
             customLoader = appContext;
         }

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinServletContextInitializer.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinServletContextInitializer.java
@@ -607,6 +607,10 @@ public class VaadinServletContextInitializer
                 "org/springframework", "org/webjars/bowergithub", "org/yaml")
                 .collect(Collectors.toList());
 
+        private static List<String> defaultWhiteList =
+                DEFAULT_WHITE_LISTED.stream().map(packageName -> packageName.replace('.',
+                        '/')).collect(Collectors.toList());
+
         public CustomResourceLoader(ResourceLoader resourceLoader,
                                     List<String> addedBlacklist) {
             super(resourceLoader);
@@ -654,7 +658,7 @@ public class VaadinServletContextInitializer
                     rootPaths.add(path);
                     resourcesList.add(resource);
                 } else {
-                    int index = path.indexOf(".jar!/");
+                    int index = path.lastIndexOf(".jar!/");
                     if (index >= 0) {
                         String relativePath = path.substring(index + 6);
                         if (shouldPathBeScanned(relativePath)) {
@@ -681,7 +685,7 @@ public class VaadinServletContextInitializer
         }
 
         private boolean shouldPathBeScanned(String path) {
-            if (DEFAULT_WHITE_LISTED.stream().anyMatch(path::startsWith)) {
+            if (defaultWhiteList.stream().anyMatch(path::startsWith)) {
                 return true;
             }
 

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinServletContextInitializer.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinServletContextInitializer.java
@@ -300,8 +300,7 @@ public class VaadinServletContextInitializer
                 return;
             }
 
-            // Handle classes Route.class, NpmPackage.class,
-            // WebComponentExporter.class
+
             Set<String> basePackages;
             ResourceLoader resourceLoader;
             if (isWhitelistSet()) {
@@ -312,6 +311,8 @@ public class VaadinServletContextInitializer
                 resourceLoader = customLoader;
             }
 
+            // Handle classes Route.class, NpmPackage.class,
+            // WebComponentExporter.class
             long start = System.currentTimeMillis();
             Set<Class<?>> classes = findByAnnotation(basePackages, resourceLoader,
                     Route.class, NpmPackage.class, NpmPackage.Container.class)
@@ -361,6 +362,19 @@ public class VaadinServletContextInitializer
         @Override
         public void contextDestroyed(ServletContextEvent event) {
             // NO-OP
+        }
+
+        private Collection<String> getWhiteListPackages() {
+            HashSet<String> npmPackages = new HashSet<>(getDefaultPackages());
+            npmPackages.addAll(DEFAULT_WHITE_LISTED);
+            if (customWhitelist != null) {
+                npmPackages.addAll(customWhitelist);
+            }
+            return npmPackages;
+        }
+
+        private boolean isWhitelistSet() {
+            return customWhitelist != null && !customWhitelist.isEmpty();
         }
     }
 
@@ -552,15 +566,6 @@ public class VaadinServletContextInitializer
                 .collect(Collectors.toSet());
     }
 
-    private Collection<String> getWhiteListPackages() {
-        HashSet<String> npmPackages = new HashSet<>(getDefaultPackages());
-        npmPackages.addAll(DEFAULT_WHITE_LISTED);
-        if (customWhitelist != null) {
-            npmPackages.addAll(customWhitelist);
-        }
-        return npmPackages;
-    }
-
     private List<String> getDefaultPackages() {
         List<String> packagesList = Collections.emptyList();
         if (appContext
@@ -578,10 +583,6 @@ public class VaadinServletContextInitializer
             packagesList = AutoConfigurationPackages.get(appContext);
         }
         return packagesList;
-    }
-
-    private boolean isWhitelistSet() {
-        return customWhitelist != null && !customWhitelist.isEmpty();
     }
 
     /**

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinServletContextInitializer.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinServletContextInitializer.java
@@ -81,6 +81,7 @@ import com.vaadin.flow.server.startup.WebComponentConfigurationRegistryInitializ
 import com.vaadin.flow.server.startup.WebComponentExporterAwareValidator;
 import com.vaadin.flow.server.webcomponent.WebComponentConfigurationRegistry;
 import com.vaadin.flow.spring.VaadinScanPackagesRegistrar.VaadinScanPackages;
+import com.vaadin.flow.theme.Theme;
 
 /**
  * Servlet context initializer for Spring Boot Application.
@@ -565,7 +566,12 @@ public class VaadinServletContextInitializer
          * can't be overriden by <code>addedWhiteListed</code>.
          */
         private final static List<String> DEFAULT_WHITE_LISTED = Stream
-                .of("com/vaadin/flow/component").collect(Collectors.toList());
+                .of(
+                        Component.class.getPackage().getName(),
+                        Theme.class.getPackage().getName(),
+                        "com/vaadin/shrinkwrap"
+                ).map(name -> name.replace('.', '/'))
+                .collect(Collectors.toList());
 
         /**
          * Blacklisted packages that shouldn't be scanned for when scanning all

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinServletContextInitializer.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinServletContextInitializer.java
@@ -105,7 +105,7 @@ public class VaadinServletContextInitializer
      * packages that are white-listed (should be scanned) by default and
      * can't be overriden by <code>addedWhiteListed</code>.
      */
-    private final static List<String> DEFAULT_WHITE_LISTED = Stream
+    private static final List<String> DEFAULT_WHITE_LISTED = Stream
             .of(
                     Component.class.getPackage().getName(),
                     Theme.class.getPackage().getName(),
@@ -303,14 +303,17 @@ public class VaadinServletContextInitializer
             // Handle classes Route.class, NpmPackage.class,
             // WebComponentExporter.class
             Set<String> basePackages;
+            ResourceLoader resourceLoader;
             if (isWhitelistSet()) {
                 basePackages = new HashSet<>(getWhiteListPackages());
+                resourceLoader = appContext;
             } else {
                 basePackages = Collections.singleton("");
+                resourceLoader = customLoader;
             }
 
             long start = System.currentTimeMillis();
-            Set<Class<?>> classes = findByAnnotation(basePackages, customLoader,
+            Set<Class<?>> classes = findByAnnotation(basePackages, resourceLoader,
                     Route.class, NpmPackage.class, NpmPackage.Container.class)
                             .collect(Collectors.toSet());
             long annotationScanning = System.currentTimeMillis();
@@ -318,21 +321,21 @@ public class VaadinServletContextInitializer
                     "Search for classes with annotations took {} seconds",
                     (annotationScanning - start) / 1000);
 
-            classes.addAll(findBySuperType(basePackages, customLoader,
+            classes.addAll(findBySuperType(basePackages, resourceLoader,
                     WebComponentExporter.class).collect(Collectors.toSet()));
             long webComponentsScanning = System.currentTimeMillis();
             getLogger().info(SEARCH_TIME_MESSAGE,
                     WebComponentExporter.class.getSimpleName(),
                     (webComponentsScanning - annotationScanning) / 1000);
 
-            classes.addAll(findBySuperType(basePackages, customLoader,
+            classes.addAll(findBySuperType(basePackages, resourceLoader,
                     UIInitListener.class).collect(Collectors.toSet()));
             long uiInitScanning = System.currentTimeMillis();
             getLogger().info(SEARCH_TIME_MESSAGE,
                     UIInitListener.class.getSimpleName(),
                     (uiInitScanning - webComponentsScanning) / 1000);
 
-            classes.addAll(findBySuperType(basePackages, customLoader,
+            classes.addAll(findBySuperType(basePackages, resourceLoader,
                     VaadinServiceInitListener.class)
                             .collect(Collectors.toSet()));
             long serviceInitScanning = System.currentTimeMillis();

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinServletContextInitializer.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinServletContextInitializer.java
@@ -442,8 +442,8 @@ public class VaadinServletContextInitializer
 
         } else {
             customWhitelist = Arrays.stream(whitelistProperty.split(","))
-                    .map(s -> s.replace('/', '.'))
-                    .map(String::trim).collect(Collectors.toList());
+                    .map(whitelistedPackage -> whitelistedPackage.replace('/', '.').trim())
+                    .collect(Collectors.toList());
             customLoader = appContext;
         }
 


### PR DESCRIPTION
Expanded default whitelist. Now preserves shrinkwrap and themes.

@caalador: I must admit, I still didn't fully grasp what you wanted to happen with the whitelist implementation, so I did my best guess and you'll have better time pointing out goofs on the review. Should the whitelist be somehow applied to the other listeners as well, so that i.e. routes would be scanned only from whitelisted things. Though now the default packages are a subset of the whitelisted packages. Which does not seem quite right either. 

Fixes https://github.com/vaadin/flow/issues/6404

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/spring/488)
<!-- Reviewable:end -->
