### PR TITLE
Do not throw IllegalStateException("Current VaadinSession is not open…

### DIFF
--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/scopes/AbstractScope.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/scopes/AbstractScope.java
@@ -75,7 +75,7 @@ abstract class AbstractScope implements Scope, BeanFactoryPostProcessor {
             throw new IllegalStateException(
                     "No VaadinSession bound to current thread");
         }
-        if (session.getState() != VaadinSessionState.OPEN) {
+        if (!session.getConfiguration().isProductionMode() && (session.getState() != VaadinSessionState.OPEN)) {
             throw new IllegalStateException(
                     "Current VaadinSession is not open");
         }


### PR DESCRIPTION
Do not throw IllegalStateException("Current VaadinSession is not open") in production mode

Addresses https://github.com/vaadin/spring/issues/487

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/spring/506)
<!-- Reviewable:end -->
