### PR TITLE
Fix Spring for Flow 2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
 
         <!-- These are typically overridden with BOMs -->
-        <vaadin.flow.version>2.1-SNAPSHOT</vaadin.flow.version>
+        <vaadin.flow.version>2.2-SNAPSHOT</vaadin.flow.version>
         <spring-boot.version>2.2.0.RELEASE</spring-boot.version>
 
         <!-- Additional manifest fields -->

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     </parent>
 
     <artifactId>vaadin-spring-parent</artifactId>
-    <version>12.1-SNAPSHOT</version>
+    <version>12.2-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>vaadin-spring-parent</name>

--- a/vaadin-spring-boot-starter/pom.xml
+++ b/vaadin-spring-boot-starter/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <skipTests>true</skipTests>
-        <vaadin.platform.version>11.0-SNAPSHOT</vaadin.platform.version>
+        <vaadin.platform.version>14.1-SNAPSHOT</vaadin.platform.version>
     </properties>
 
     <dependencyManagement>

--- a/vaadin-spring-boot-starter/pom.xml
+++ b/vaadin-spring-boot-starter/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-spring-parent</artifactId>
-        <version>12.1-SNAPSHOT</version>
+        <version>12.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>vaadin-spring-boot-starter</artifactId>
     <name>Spring Boot Starter</name>
-    <version>12.1-SNAPSHOT</version>
+    <version>12.2-SNAPSHOT</version>
     <description>
         Spring Boot Starter for Vaadin Flow applications.
     </description>

--- a/vaadin-spring-tests/dummy-module/pom.xml
+++ b/vaadin-spring-tests/dummy-module/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-spring-tests</artifactId>
-        <version>12.1-SNAPSHOT</version>
+        <version>12.2-SNAPSHOT</version>
     </parent>
     <artifactId>dummy-module</artifactId>
     <name>Keep this module as the last one in the list</name>

--- a/vaadin-spring-tests/pom.xml
+++ b/vaadin-spring-tests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-spring-parent</artifactId>
-        <version>12.1-SNAPSHOT</version>
+        <version>12.2-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-spring-tests</artifactId>
     <name>Vaadin Spring tests</name>

--- a/vaadin-spring-tests/test-spring-boot-contextpath/pom-bower-mode.xml
+++ b/vaadin-spring-tests/test-spring-boot-contextpath/pom-bower-mode.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-spring-tests</artifactId>
-        <version>12.1-SNAPSHOT</version>
+        <version>12.2-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-test-spring-boot-contextpath-bower-mode</artifactId>
     <name>Vaadin Spring Boot integration tests when deployed using a context path in bower mode</name>

--- a/vaadin-spring-tests/test-spring-boot-contextpath/pom.xml
+++ b/vaadin-spring-tests/test-spring-boot-contextpath/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-spring-tests</artifactId>
-        <version>12.1-SNAPSHOT</version>
+        <version>12.2-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-test-spring-boot-contextpath</artifactId>
     <name>Vaadin Spring Boot integration tests when deployed using a context path</name>

--- a/vaadin-spring-tests/test-spring-boot-only-prepare/pom.xml
+++ b/vaadin-spring-tests/test-spring-boot-only-prepare/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-spring-tests</artifactId>
-        <version>12.1-SNAPSHOT</version>
+        <version>12.2-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-test-spring-boot-prepare</artifactId>
     <name>Vaadin Spring Boot integration tests with only prepare goal</name>

--- a/vaadin-spring-tests/test-spring-boot-only-prepare/pom.xml
+++ b/vaadin-spring-tests/test-spring-boot-only-prepare/pom.xml
@@ -64,16 +64,6 @@
     <build>
         <pluginManagement>
             <plugins>
-                <plugin>
-                    <groupId>org.springframework.boot</groupId>
-                    <artifactId>spring-boot-maven-plugin</artifactId>
-                    <version>${spring-boot.version}</version>
-                    <configuration>
-                        <maxAttempts>60</maxAttempts>
-                        <wait>2500</wait>
-                    </configuration>
-                </plugin>
-
                 <!--This plugin's configuration is used to store Eclipse
                     m2e settings only. It has no influence on the Maven build itself. -->
                 <plugin>
@@ -151,6 +141,10 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <maxAttempts>60</maxAttempts>
+                    <wait>2500</wait>
+                </configuration>
                 <executions>
                     <!-- start and stop application when running
                         integration tests -->

--- a/vaadin-spring-tests/test-spring-boot-only-prepare/pom.xml
+++ b/vaadin-spring-tests/test-spring-boot-only-prepare/pom.xml
@@ -69,7 +69,7 @@
                     <artifactId>spring-boot-maven-plugin</artifactId>
                     <version>${spring-boot.version}</version>
                     <configuration>
-                        <maxAttempts>30</maxAttempts>
+                        <maxAttempts>60</maxAttempts>
                         <wait>2500</wait>
                     </configuration>
                 </plugin>

--- a/vaadin-spring-tests/test-spring-boot-scan/pom-bower-mode.xml
+++ b/vaadin-spring-tests/test-spring-boot-scan/pom-bower-mode.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-spring-tests</artifactId>
-        <version>12.1-SNAPSHOT</version>
+        <version>12.2-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-test-spring-boot-scan-bower-mode</artifactId>
     <name>Vaadin Spring Boot integration tests with custom packages to scan in bower mode</name>

--- a/vaadin-spring-tests/test-spring-boot-scan/pom.xml
+++ b/vaadin-spring-tests/test-spring-boot-scan/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-spring-tests</artifactId>
-        <version>12.1-SNAPSHOT</version>
+        <version>12.2-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-test-spring-boot-scan</artifactId>
     <name>Vaadin Spring Boot integration tests with custom packages to scan</name>

--- a/vaadin-spring-tests/test-spring-boot-undertow/pom-bower-mode.xml
+++ b/vaadin-spring-tests/test-spring-boot-undertow/pom-bower-mode.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-spring-tests</artifactId>
-        <version>12.1-SNAPSHOT</version>
+        <version>12.2-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-test-spring-boot-undertow-bower-mode</artifactId>
     <name>Vaadin Spring Boot integration tests when running on Undertow in bower mode</name>

--- a/vaadin-spring-tests/test-spring-boot-undertow/pom.xml
+++ b/vaadin-spring-tests/test-spring-boot-undertow/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-spring-tests</artifactId>
-        <version>12.1-SNAPSHOT</version>
+        <version>12.2-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-test-spring-boot-undertow</artifactId>
     <name>Vaadin Spring Boot integration tests when running on Undertow</name>

--- a/vaadin-spring-tests/test-spring-boot/pom-bower-mode.xml
+++ b/vaadin-spring-tests/test-spring-boot/pom-bower-mode.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-spring-tests</artifactId>
-        <version>12.1-SNAPSHOT</version>
+        <version>12.2-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-test-spring-boot-bower-mode</artifactId>
     <name>Vaadin Spring Boot integration tests in bower mode</name>

--- a/vaadin-spring-tests/test-spring-boot/pom.xml
+++ b/vaadin-spring-tests/test-spring-boot/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-spring-tests</artifactId>
-        <version>12.1-SNAPSHOT</version>
+        <version>12.2-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-test-spring-boot</artifactId>
     <name>Vaadin Spring Boot integration tests</name>

--- a/vaadin-spring-tests/test-spring-common/pom.xml
+++ b/vaadin-spring-tests/test-spring-common/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-spring-tests</artifactId>
-        <version>12.1-SNAPSHOT</version>
+        <version>12.2-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-test-spring-common</artifactId>
     <name>Flow Spring Common UI components</name>

--- a/vaadin-spring-tests/test-spring-war/pom-bower-mode.xml
+++ b/vaadin-spring-tests/test-spring-war/pom-bower-mode.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-spring-tests</artifactId>
-        <version>12.1-SNAPSHOT</version>
+        <version>12.2-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-test-spring-war-bower-mode</artifactId>
     <name>Vaadin Spring Boot deployable integration tests in bower mode</name>

--- a/vaadin-spring-tests/test-spring-war/pom.xml
+++ b/vaadin-spring-tests/test-spring-war/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-spring-tests</artifactId>
-        <version>12.1-SNAPSHOT</version>
+        <version>12.2-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-test-spring-war</artifactId>
     <name>Vaadin Spring Boot deployable integration tests</name>

--- a/vaadin-spring-tests/test-spring-white-list/pom.xml
+++ b/vaadin-spring-tests/test-spring-white-list/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-spring-tests</artifactId>
-        <version>12.1-SNAPSHOT</version>
+        <version>12.2-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-test-spring-white-list</artifactId>
 

--- a/vaadin-spring-tests/test-spring/pom-bower-mode.xml
+++ b/vaadin-spring-tests/test-spring/pom-bower-mode.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-spring-tests</artifactId>
-        <version>12.1-SNAPSHOT</version>
+        <version>12.2-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-test-spring-bower-mode</artifactId>
     <name>Flow Spring deployable integration tests in bower mode</name>

--- a/vaadin-spring-tests/test-spring/pom.xml
+++ b/vaadin-spring-tests/test-spring/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-spring-tests</artifactId>
-        <version>12.1-SNAPSHOT</version>
+        <version>12.2-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-test-spring</artifactId>
     <name>Flow Spring deployable integration tests</name>

--- a/vaadin-spring/pom.xml
+++ b/vaadin-spring/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-spring-parent</artifactId>
-        <version>12.1-SNAPSHOT</version>
+        <version>12.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>vaadin-spring</artifactId>

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinServletContextInitializer.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinServletContextInitializer.java
@@ -69,6 +69,9 @@ import com.vaadin.flow.server.DeploymentConfigurationFactory;
 import com.vaadin.flow.server.DevModeHandler;
 import com.vaadin.flow.server.InvalidRouteConfigurationException;
 import com.vaadin.flow.server.RouteRegistry;
+import com.vaadin.flow.server.VaadinConfig;
+import com.vaadin.flow.server.VaadinConfigurationException;
+import com.vaadin.flow.server.VaadinServletConfig;
 import com.vaadin.flow.server.VaadinServletContext;
 import com.vaadin.flow.server.startup.AbstractRouteRegistryInitializer;
 import com.vaadin.flow.server.startup.AnnotationValidator;
@@ -757,8 +760,8 @@ public class VaadinServletContextInitializer
                         context, registration, appContext);
                 return DeploymentConfigurationFactory
                         .createPropertyDeploymentConfiguration(servletClass,
-                                servletConfig);
-            } catch (ServletException e) {
+                                new VaadinServletConfig(servletConfig));
+            } catch (VaadinConfigurationException e) {
                 throw new IllegalStateException(String.format(
                         "Failed to get deployment configuration data for servlet with name '%s' and class '%s'",
                         registration.getServletName(), servletClass), e);

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinServletContextInitializer.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinServletContextInitializer.java
@@ -69,7 +69,6 @@ import com.vaadin.flow.server.DeploymentConfigurationFactory;
 import com.vaadin.flow.server.DevModeHandler;
 import com.vaadin.flow.server.InvalidRouteConfigurationException;
 import com.vaadin.flow.server.RouteRegistry;
-import com.vaadin.flow.server.VaadinConfig;
 import com.vaadin.flow.server.VaadinConfigurationException;
 import com.vaadin.flow.server.VaadinServletConfig;
 import com.vaadin.flow.server.VaadinServletContext;


### PR DESCRIPTION
Note after this is merged Spring master will be 12.2-Snapshot that builds against Flow 2.2 and 
Spring for Flow 2.1 should be built from the 12.1 branch.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/spring/509)
<!-- Reviewable:end -->
