### PR TITLE
Scan abstract types

### DIFF
--- a/vaadin-spring-tests/test-spring-boot-only-prepare/pom.xml
+++ b/vaadin-spring-tests/test-spring-boot-only-prepare/pom.xml
@@ -142,7 +142,7 @@
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
                 <configuration>
-                    <maxAttempts>120</maxAttempts>
+                    <maxAttempts>60</maxAttempts>
                     <wait>2500</wait>
                 </configuration>
                 <executions>

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinServletContextInitializer.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinServletContextInitializer.java
@@ -22,6 +22,7 @@ import javax.servlet.ServletContextEvent;
 import javax.servlet.ServletContextListener;
 import javax.servlet.ServletException;
 import javax.servlet.annotation.HandlesTypes;
+
 import java.io.IOException;
 import java.lang.annotation.Annotation;
 import java.util.ArrayList;
@@ -34,7 +35,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.Collectors;
@@ -315,38 +315,12 @@ public class VaadinServletContextInitializer
                     "Search for subclasses and classes with annotations took {} seconds",
                     (classScanning - start) / 1000);
 
-            classes.addAll(getOtherRequiredTypes());
-
             try {
                 DevModeInitializer.initDevModeHandler(classes,
                         event.getServletContext(), config);
             } catch (ServletException e) {
                 throw new RuntimeException(
                         "Unable to initialize Vaadin DevModeHandler", e);
-            }
-        }
-
-        private Collection<Class<?>> getOtherRequiredTypes() {
-            List<Class<?>> types = new ArrayList<>();
-
-            // DragSource and DropTarget, two interfaces in flow-dnd module that
-            // are essential for supporting drag and drop, are not scanned
-            // because Spring doesn't scan interfaces. So, we have to add them
-            // manually.
-            getClassByName("com.vaadin.flow.component.dnd.DragSource")
-                    .ifPresent(types::add);
-            getClassByName("com.vaadin.flow.component.dnd.DropTarget")
-                    .ifPresent(types::add);
-
-            return types;
-        }
-
-        private Optional<Class> getClassByName(String name) {
-            try {
-                return Optional.of(Class
-                        .forName(name));
-            } catch (ClassNotFoundException e) {
-                return Optional.empty();
             }
         }
 

--- a/vaadin-spring/src/test/java/com/vaadin/flow/spring/SpringClassesSerializableTest.java
+++ b/vaadin-spring/src/test/java/com/vaadin/flow/spring/SpringClassesSerializableTest.java
@@ -79,6 +79,7 @@ public class SpringClassesSerializableTest extends ClassesSerializableTest {
                 "com\\.vaadin\\.flow\\.spring\\.scopes\\.VaadinSessionScope",
                 "com\\.vaadin\\.flow\\.spring\\.scopes\\.AbstractScope",
                 "com\\.vaadin\\.flow\\.spring\\.scopes\\.VaadinUIScope",
+                "com\\.vaadin\\.flow\\.spring\\.VaadinServletContextInitializer\\$ClassPathScanner",
                 "com\\.vaadin\\.flow\\.spring\\.VaadinServletContextInitializer\\$CustomResourceLoader"),
                 super.getExcludedPatterns());
     }


### PR DESCRIPTION
Reverts the hardcoded workaround for #519 and instead configures the
classpath scanning logic to consider all abstract types.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/spring/525)
<!-- Reviewable:end -->
