### PR TITLE
Fix failed test because a new constant was added in Flow

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
 
         <!-- These are typically overridden with BOMs -->
-        <vaadin.flow.version>3.0-SNAPSHOT</vaadin.flow.version>
+        <vaadin.flow.version>3.1-SNAPSHOT</vaadin.flow.version>
         <spring-boot.version>2.2.0.RELEASE</spring-boot.version>
 
         <!-- Additional manifest fields -->

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
 
         <!-- These are typically overridden with BOMs -->
-        <vaadin.flow.version>3.1-SNAPSHOT</vaadin.flow.version>
+        <vaadin.flow.version>3.0-SNAPSHOT</vaadin.flow.version>
         <spring-boot.version>2.2.0.RELEASE</spring-boot.version>
 
         <!-- Additional manifest fields -->

--- a/vaadin-spring/src/test/java/com/vaadin/flow/spring/DeploymentConfigurationPropertiesTest.java
+++ b/vaadin-spring/src/test/java/com/vaadin/flow/spring/DeploymentConfigurationPropertiesTest.java
@@ -71,7 +71,7 @@ public class DeploymentConfigurationPropertiesTest {
 
         // Check that we have added all other constants as parameters (except
         // those we know)
-        Assert.assertEquals(46, constantsCopy.size());
+        Assert.assertEquals(47, constantsCopy.size());
 
         Assert.assertTrue(constantsCopy
                 .contains(Constants.REQUIRED_ATMOSPHERE_RUNTIME_VERSION));

--- a/vaadin-spring/src/test/java/com/vaadin/flow/spring/DeploymentConfigurationPropertiesTest.java
+++ b/vaadin-spring/src/test/java/com/vaadin/flow/spring/DeploymentConfigurationPropertiesTest.java
@@ -114,5 +114,7 @@ public class DeploymentConfigurationPropertiesTest {
                 Constants.SERVLET_PARAMETER_WEB_COMPONENT_DISCONNECT));
         Assert.assertTrue(
                 constantsCopy.contains(Constants.VAADIN_VERSIONS_JSON));
+        Assert.assertTrue(
+                constantsCopy.contains(Constants.REQUIRE_HOME_NODE_EXECUTABLE));
     }
 }


### PR DESCRIPTION
* Update Flow version to 3.1-SNAPSHOT
* Add a new constant `REQUIRE_HOME_NODE_EXECUTABLE` for the test

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/spring/562)
<!-- Reviewable:end -->
