### PR TITLE
Flow Spring 12.2 nightly build for Bower mode fails #605

### DIFF
--- a/vaadin-spring-tests/pom.xml
+++ b/vaadin-spring-tests/pom.xml
@@ -28,6 +28,13 @@
         <driver.binary.downloader.maven.plugin.version>1.0.14
         </driver.binary.downloader.maven.plugin.version>
         <maven.war.plugin.version>3.1.0</maven.war.plugin.version>
+
+
+        <!-- Specify the same port for both JMX and RMI in order to avoid the issues
+             with JMX connection between spring-boot-maven-plugin and Spring Boot application
+             Workaround for https://github.com/vaadin/spring/issues/605 -->
+        <spring.jmxremote.port>9001</spring.jmxremote.port>
+        <spring.rmi.port>9001</spring.rmi.port>
     </properties>
 
     <dependencyManagement>
@@ -353,6 +360,10 @@
                         <artifactId>spring-boot-maven-plugin</artifactId>
                         <configuration>
                             <jvmArguments>-Dvaadin.compatibilityMode</jvmArguments>
+                            <systemPropertyVariables>
+                                <com.sun.management.jmxremote.port>${spring.jmxremote.port}</com.sun.management.jmxremote.port>
+                                <com.sun.management.jmxremote.rmi.port>${spring.rmi.port}</com.sun.management.jmxremote.rmi.port>
+                            </systemPropertyVariables>
                         </configuration>
                     </plugin>
                 </plugins>


### PR DESCRIPTION
Fixes #605 
Pointed to 12.2 in order to keep 12.2 nightly builds under observation for a while.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/spring/607)
<!-- Reviewable:end -->
