### PR TITLE
Remove PWA Dialog test (vaadin/flow#8038)

### DIFF
--- a/vaadin-spring-tests/test-ts-services/src/test/java/com/vaadin/flow/connect/AppViewIT.java
+++ b/vaadin-spring-tests/test-ts-services/src/test/java/com/vaadin/flow/connect/AppViewIT.java
@@ -150,12 +150,6 @@ public class AppViewIT extends ChromeBrowserTest {
     }
 
     @Test
-    public void should_show_pwaDialog() {
-        WebElement pwa = findElement(By.id("pwa-ip"));
-        Assert.assertTrue(pwa.getText().contains("My App"));
-    }
-
-    @Test
     public void should_beAble_toLogin_usingSpringForm() {
         // Login by using the Spring Login Form
         openTestUrl("/login");


### PR DESCRIPTION
Part of vaadin/flow#8038
Remove PWA Dialog Test as this feature is not available anymore.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/spring/614)
<!-- Reviewable:end -->
