### PR TITLE
Fix build of Spring 10.0 for Flow 1.0

### DIFF
--- a/vaadin-spring-tests/test-spring-common/pom.xml
+++ b/vaadin-spring-tests/test-spring-common/pom.xml
@@ -33,6 +33,11 @@
             <version>2.6.0</version>
         </dependency>
 
+        <dependency>
+            <groupId>org.webjars.bowergithub.webcomponents</groupId>
+            <artifactId>webcomponentsjs</artifactId>
+            <version>1.2.2</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/vaadin-spring-tests/test-spring-common/src/main/java/com/vaadin/flow/spring/test/StreamResourceView.java
+++ b/vaadin-spring-tests/test-spring-common/src/main/java/com/vaadin/flow/spring/test/StreamResourceView.java
@@ -34,7 +34,7 @@ public class StreamResourceView extends Div {
                         "Hello world".getBytes(StandardCharsets.UTF_8)));
         Anchor download = new Anchor("", "Download file");
         download.setHref(resource);
-        download.setId("download");
+        download.setId("downloadLink");
         add(download);
     }
 }

--- a/vaadin-spring-tests/test-spring-common/src/test/java/com/vaadin/flow/spring/test/StreamResourceIT.java
+++ b/vaadin-spring-tests/test-spring-common/src/test/java/com/vaadin/flow/spring/test/StreamResourceIT.java
@@ -42,7 +42,7 @@ public class StreamResourceIT extends AbstractSpringTest {
     public void ensureStreamResourceWorks() throws IOException {
         open();
 
-        WebElement link = findElement(By.id("download"));
+        WebElement link = findElement(By.id("downloadLink"));
         String url = link.getAttribute("href");
 
         getDriver().manage().timeouts().setScriptTimeout(15, TimeUnit.SECONDS);


### PR DESCRIPTION
ITs with templates didn't load HTML imports correctly as `webcomponentsjs` in ITs got resolved to a newer version than 1.2.2 as `polymer` has dependency `[1.1.0,2)` (passed on Chrome with native HTML import support but started failing after this was dropped since 80).

Anoter IT (`StreamResourceIT`) was failing because selector `By.id("download")` hit an SVG `<g>` element from `<iron-iconset-svg>` with the same id.

Related to vaadin/flow#8192.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/spring/616)
<!-- Reviewable:end -->
