### PR TITLE
Add `devmode.liveReload.enabled` parameter for Spring 12.2 for Flow 2.3

### DIFF
--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/SpringServlet.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/SpringServlet.java
@@ -81,6 +81,7 @@ public class SpringServlet extends VaadinServlet {
             Constants.FRONTEND_URL_ES5, Constants.FRONTEND_URL_ES6,
             Constants.I18N_PROVIDER,
             Constants.DISABLE_AUTOMATIC_SERVLET_REGISTRATION,
+            "devmode.liveReload.enabled",
             VaadinSession.UI_PARAMETER);
 
     private final ApplicationContext context;

--- a/vaadin-spring/src/test/java/com/vaadin/flow/spring/DeploymentConfigurationPropertiesTest.java
+++ b/vaadin-spring/src/test/java/com/vaadin/flow/spring/DeploymentConfigurationPropertiesTest.java
@@ -27,6 +27,7 @@ import org.junit.Test;
 
 import com.vaadin.flow.server.Constants;
 import com.vaadin.flow.server.VaadinSession;
+import com.vaadin.flow.server.Version;
 
 public class DeploymentConfigurationPropertiesTest {
 
@@ -66,12 +67,21 @@ public class DeploymentConfigurationPropertiesTest {
         // Check that the only parameter which is not in Constants is
         // UI_PARAMETER
         list.removeAll(constants);
-        Assert.assertEquals(1, list.size());
-        Assert.assertEquals(VaadinSession.UI_PARAMETER, list.get(0));
 
-        // Check that we have added all other constants as parameters (except
-        // those we know)
-        Assert.assertEquals(42, constantsCopy.size());
+        if (Version.getFullVersion().startsWith("2.3")) {
+            Assert.assertEquals(1, list.size());
+            Assert.assertEquals(VaadinSession.UI_PARAMETER, list.get(0));
+            // Check that we have added all other constants as parameters (except
+            // those we know)
+            Assert.assertEquals(42, constantsCopy.size());
+        } else {
+            Assert.assertEquals(2, list.size());
+            Assert.assertEquals("devmode.liveReload.enabled", list.get(0));
+            Assert.assertEquals(VaadinSession.UI_PARAMETER, list.get(1));
+            // Check that we have added all other constants as parameters (except
+            // those we know)
+            Assert.assertEquals(42, constantsCopy.size());
+        }
 
         Assert.assertTrue(constantsCopy
                 .contains(Constants.REQUIRED_ATMOSPHERE_RUNTIME_VERSION));


### PR DESCRIPTION
Note: ugly temporary hack, but `DeploymentConfigurationPropertiesTest` and explicit parameter listing in `SpringServlet` will go away with vaadin/flow#8321.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/spring/624)
<!-- Reviewable:end -->
