### PR TITLE
Flow Spring 12.2 nightly build for Bower mode fails #605

### DIFF
--- a/vaadin-spring-tests/pom.xml
+++ b/vaadin-spring-tests/pom.xml
@@ -28,13 +28,6 @@
         <driver.binary.downloader.maven.plugin.version>1.0.14
         </driver.binary.downloader.maven.plugin.version>
         <maven.war.plugin.version>3.1.0</maven.war.plugin.version>
-
-
-        <!-- Specify the same port for both JMX and RMI in order to avoid the issues
-             with JMX connection between spring-boot-maven-plugin and Spring Boot application
-             Workaround for https://github.com/vaadin/spring/issues/605 -->
-        <spring.jmxremote.port>9001</spring.jmxremote.port>
-        <spring.rmi.port>9001</spring.rmi.port>
     </properties>
 
     <dependencyManagement>
@@ -359,11 +352,13 @@
                         <groupId>org.springframework.boot</groupId>
                         <artifactId>spring-boot-maven-plugin</artifactId>
                         <configuration>
-                            <jvmArguments>-Dvaadin.compatibilityMode</jvmArguments>
-                            <systemPropertyVariables>
-                                <com.sun.management.jmxremote.port>${spring.jmxremote.port}</com.sun.management.jmxremote.port>
-                                <com.sun.management.jmxremote.rmi.port>${spring.rmi.port}</com.sun.management.jmxremote.rmi.port>
-                            </systemPropertyVariables>
+                            <!-- Disable JVM fork mode for applications started by spring-boot-maven-plugin
+                            in order to avoid the issues with JMX connection between spring-boot-maven-plugin
+                            and Spring Boot application.
+                            NOTE: <jvmArguments>, <systemPropertyVariables> tags are ignored in
+                            fork mode and the properties should be set via TestUtils class.
+                            Workaround for https://github.com/vaadin/spring/issues/605 -->
+                            <fork>false</fork>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/vaadin-spring-tests/test-spring-boot-contextpath/src/main/java/com/vaadin/flow/spring/test/TestServletInitializer.java
+++ b/vaadin-spring-tests/test-spring-boot-contextpath/src/main/java/com/vaadin/flow/spring/test/TestServletInitializer.java
@@ -15,7 +15,7 @@
  */
 package com.vaadin.flow.spring.test;
 
-import org.springframework.boot.SpringApplication;
+import com.vaadin.flow.spring.test.util.TestUtils;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -32,7 +32,7 @@ import org.springframework.security.oauth2.config.annotation.web.configurers.Aut
 public class TestServletInitializer implements AuthorizationServerConfigurer {
 
     public static void main(String[] args) {
-        SpringApplication.run(TestServletInitializer.class, args);
+        TestUtils.startSpringApplication(TestServletInitializer.class, args);
     }
 
     @Override

--- a/vaadin-spring-tests/test-spring-boot-only-prepare/src/main/java/com/vaadin/flow/spring/test/TestServletInitializer.java
+++ b/vaadin-spring-tests/test-spring-boot-only-prepare/src/main/java/com/vaadin/flow/spring/test/TestServletInitializer.java
@@ -15,7 +15,6 @@
  */
 package com.vaadin.flow.spring.test;
 
-import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -27,6 +26,8 @@ import org.springframework.security.oauth2.config.annotation.web.configurers.Aut
 import org.springframework.security.oauth2.config.annotation.web.configurers.AuthorizationServerSecurityConfigurer;
 import org.springframework.web.multipart.commons.CommonsMultipartResolver;
 
+import com.vaadin.flow.spring.test.util.TestUtils;
+
 @SpringBootApplication
 @EnableAuthorizationServer
 @Configuration
@@ -34,7 +35,7 @@ import org.springframework.web.multipart.commons.CommonsMultipartResolver;
 public class TestServletInitializer implements AuthorizationServerConfigurer {
 
     public static void main(String[] args) {
-        SpringApplication.run(TestServletInitializer.class, args);
+        TestUtils.startSpringApplication(TestServletInitializer.class, args);
     }
 
     @Override

--- a/vaadin-spring-tests/test-spring-boot-scan/src/main/java/com/vaadin/flow/spring/scan/test/TestServletInitializer.java
+++ b/vaadin-spring-tests/test-spring-boot-scan/src/main/java/com/vaadin/flow/spring/scan/test/TestServletInitializer.java
@@ -15,7 +15,8 @@
  */
 package com.vaadin.flow.spring.scan.test;
 
-import org.springframework.boot.SpringApplication;
+import com.vaadin.flow.spring.annotation.EnableVaadin;
+import com.vaadin.flow.spring.test.util.TestUtils;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
@@ -26,8 +27,6 @@ import org.springframework.security.oauth2.config.annotation.web.configuration.E
 import org.springframework.security.oauth2.config.annotation.web.configurers.AuthorizationServerEndpointsConfigurer;
 import org.springframework.security.oauth2.config.annotation.web.configurers.AuthorizationServerSecurityConfigurer;
 
-import com.vaadin.flow.spring.annotation.EnableVaadin;
-
 @SpringBootApplication
 @EnableAuthorizationServer
 @Configuration
@@ -37,7 +36,7 @@ import com.vaadin.flow.spring.annotation.EnableVaadin;
 public class TestServletInitializer implements AuthorizationServerConfigurer {
 
     public static void main(String[] args) {
-        SpringApplication.run(TestServletInitializer.class, args);
+        TestUtils.startSpringApplication(TestServletInitializer.class, args);
     }
 
     @Override

--- a/vaadin-spring-tests/test-spring-boot-undertow/src/main/java/com/vaadin/flow/spring/test/TestServletInitializer.java
+++ b/vaadin-spring-tests/test-spring-boot-undertow/src/main/java/com/vaadin/flow/spring/test/TestServletInitializer.java
@@ -15,7 +15,6 @@
  */
 package com.vaadin.flow.spring.test;
 
-import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -25,6 +24,8 @@ import org.springframework.security.oauth2.config.annotation.web.configuration.E
 import org.springframework.security.oauth2.config.annotation.web.configurers.AuthorizationServerEndpointsConfigurer;
 import org.springframework.security.oauth2.config.annotation.web.configurers.AuthorizationServerSecurityConfigurer;
 
+import com.vaadin.flow.spring.test.util.TestUtils;
+
 @SpringBootApplication
 @EnableAuthorizationServer
 @Configuration
@@ -32,7 +33,7 @@ import org.springframework.security.oauth2.config.annotation.web.configurers.Aut
 public class TestServletInitializer implements AuthorizationServerConfigurer {
 
     public static void main(String[] args) {
-        SpringApplication.run(TestServletInitializer.class, args);
+        TestUtils.startSpringApplication(TestServletInitializer.class, args);
     }
 
     @Override

--- a/vaadin-spring-tests/test-spring-boot/src/main/java/com/vaadin/flow/spring/test/TestServletInitializer.java
+++ b/vaadin-spring-tests/test-spring-boot/src/main/java/com/vaadin/flow/spring/test/TestServletInitializer.java
@@ -15,7 +15,7 @@
  */
 package com.vaadin.flow.spring.test;
 
-import org.springframework.boot.SpringApplication;
+import com.vaadin.flow.spring.test.util.TestUtils;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -34,7 +34,7 @@ import org.springframework.web.multipart.commons.CommonsMultipartResolver;
 public class TestServletInitializer implements AuthorizationServerConfigurer {
 
     public static void main(String[] args) {
-        SpringApplication.run(TestServletInitializer.class, args);
+        TestUtils.startSpringApplication(TestServletInitializer.class, args);
     }
 
     @Override

--- a/vaadin-spring-tests/test-spring-common/src/main/java/com/vaadin/flow/spring/test/util/TestUtils.java
+++ b/vaadin-spring-tests/test-spring-common/src/main/java/com/vaadin/flow/spring/test/util/TestUtils.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2000-2020 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.spring.test.util;
+
+import org.springframework.boot.SpringApplication;
+
+/**
+ * Shared code to use in the Spring integration tests.
+ */
+public final class TestUtils {
+
+    private TestUtils() {
+    }
+
+    /**
+     * Sets Vaadin system properties and starts the Spring-boot application.
+     * @param appClass spring-boot application main class
+     * @param args java command-line arguments
+     */
+    public static void startSpringApplication(Class<?> appClass, String[] args) {
+        setVaadinProperties();
+        SpringApplication.run(appClass, args);
+    }
+
+    /**
+     * Sets an essential Vaadin system properties.
+     */
+    public static void setVaadinProperties() {
+        // Sets compatibility mode if application is launched with bower profile.
+        // Workaround for https://github.com/vaadin/spring/issues/605
+        if (System.getProperty("bowerMode") != null) {
+            System.setProperty("vaadin.compatibilityMode", "true");
+        }
+    }
+}

--- a/vaadin-spring-tests/test-spring-common/src/main/java/com/vaadin/flow/spring/test/util/TestUtils.java
+++ b/vaadin-spring-tests/test-spring-common/src/main/java/com/vaadin/flow/spring/test/util/TestUtils.java
@@ -41,8 +41,6 @@ public final class TestUtils {
     public static void setVaadinProperties() {
         // Sets compatibility mode if application is launched with bower profile.
         // Workaround for https://github.com/vaadin/spring/issues/605
-        if (System.getProperty("bowerMode") != null) {
-            System.setProperty("vaadin.compatibilityMode", "true");
-        }
+        System.setProperty("vaadin.compatibilityMode", String.valueOf(System.getProperty("bowerMode") != null));
     }
 }

--- a/vaadin-spring-tests/test-spring-white-list/src/main/java/com/vaadin/flow/spring/test/whitelist/TestServletInitializer.java
+++ b/vaadin-spring-tests/test-spring-white-list/src/main/java/com/vaadin/flow/spring/test/whitelist/TestServletInitializer.java
@@ -16,7 +16,6 @@
 
 package com.vaadin.flow.spring.test.whitelist;
 
-import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -28,6 +27,8 @@ import org.springframework.security.oauth2.config.annotation.web.configurers.Aut
 import org.springframework.security.oauth2.config.annotation.web.configurers.AuthorizationServerSecurityConfigurer;
 import org.springframework.web.multipart.commons.CommonsMultipartResolver;
 
+import com.vaadin.flow.spring.test.util.TestUtils;
+
 /**
  * The entry point of the Spring Boot application.
  */
@@ -38,7 +39,7 @@ import org.springframework.web.multipart.commons.CommonsMultipartResolver;
 public class TestServletInitializer implements AuthorizationServerConfigurer {
 
     public static void main(String[] args) {
-        SpringApplication.run(TestServletInitializer.class, args);
+        TestUtils.startSpringApplication(TestServletInitializer.class, args);
     }
 
     @Override


### PR DESCRIPTION
Fixes #605 

This PR is another attempt to workaround the bower mode build issue by disabling the fork mode for spring-boot-maven-plugin. Last time there was a silly mistake - compatibility mode has been set for all the tests which made the application run in wrong mode and led to test failures.

Now, the compatibility mode is set exactly when the bower mode (bower profile) is detected. The implementation is still using System.setProperty(), since it is critical to set those properties before Spring Application starts in order to pass the properties to Vaadin services. Spring application startup callback API (CommandLineRunner, ApplicationEvent) are invoked too late for this and can't be used.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/spring/626)
<!-- Reviewable:end -->
