### PR TITLE
Consider removing unnecessary version for hibernate validator #632

### DIFF
--- a/vaadin-spring/pom.xml
+++ b/vaadin-spring/pom.xml
@@ -86,7 +86,6 @@
         <dependency>
             <groupId>org.hibernate.validator</groupId>
             <artifactId>hibernate-validator</artifactId>
-            <version>6.1.4.Final</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Fixes #632 
`hibernate-validator` version now fetched from `org.springframework.boot:spring-boot-dependencies` pom.xml.