### PR TITLE
Minor class path scanning optimization

### DIFF
--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/PrefixTree.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/PrefixTree.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2000-2020 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.spring;
+
+import java.io.Serializable;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Quick prefix lookup for package inclusion and exclusion lists.
+ */
+class PrefixTree implements Serializable {
+
+    private final Node root;
+
+    PrefixTree(Collection<String> prefixes) {
+        root = new Node();
+        root.terminal = false;
+        prefixes.forEach(this::addPrefix);
+    }
+
+    void addPrefix(String prefix) {
+        if (prefix.isEmpty()) {
+            throw new IllegalArgumentException("empty prefix");
+        }
+        root.addPrefix(prefix);
+    }
+
+    boolean hasPrefix(String s) {
+        Node node = root;
+        final int slen = s.length();
+        int sidx = 0;
+        while (node != null) {
+            if (node.terminal) {
+                return true;
+            } else if (sidx < slen) {
+                node = node.children.get(s.charAt(sidx++));
+            } else {
+                return false;
+            }
+        }
+        return false;
+    }
+
+    static class Node implements Serializable {
+        private final Map<Character, Node> children = new HashMap<>();
+        private boolean terminal = true;
+
+        void addPrefix(String prefix) {
+            assert !prefix.isEmpty();
+            terminal = false;
+            char ch = prefix.charAt(0);
+            if (!children.containsKey(ch)) {
+                children.put(ch, new Node());
+            }
+            if (prefix.length() > 1) {
+                children.get(ch).addPrefix(prefix.substring(1));
+            }
+        }
+    }
+}

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/PrefixTree.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/PrefixTree.java
@@ -61,12 +61,9 @@ class PrefixTree implements Serializable {
         private boolean terminal = true;
 
         void addPrefix(String prefix) {
-            assert !prefix.isEmpty();
             terminal = false;
             char ch = prefix.charAt(0);
-            if (!children.containsKey(ch)) {
-                children.put(ch, new Node());
-            }
+            children.putIfAbsent(ch, new Node());
             if (prefix.length() > 1) {
                 children.get(ch).addPrefix(prefix.substring(1));
             }

--- a/vaadin-spring/src/test/java/com/vaadin/flow/spring/PrefixTreeTest.java
+++ b/vaadin-spring/src/test/java/com/vaadin/flow/spring/PrefixTreeTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2000-2020 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.spring;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class PrefixTreeTest {
+
+    @Test
+    public void hasPrefix_containsPrefix_returnsTrue() {
+        PrefixTree prefixTree = new PrefixTree(
+                Arrays.asList("com/sun", "antlr", "ch/quos/logback"));
+        Assert.assertTrue(prefixTree.hasPrefix("antlr"));
+        Assert.assertTrue(prefixTree.hasPrefix("com/sun/test"));
+        Assert.assertTrue(prefixTree.hasPrefix("com/sun"));
+    }
+
+    @Test
+    public void hasPrefix_containsPrefix_returnsFalse() {
+        PrefixTree prefixTree = new PrefixTree(
+                Arrays.asList("com/sun", "antlr", "ch/quos/logback"));
+        Assert.assertFalse(prefixTree.hasPrefix(""));
+        Assert.assertFalse(prefixTree.hasPrefix("a"));
+        Assert.assertFalse(prefixTree.hasPrefix("test"));
+        Assert.assertFalse(prefixTree.hasPrefix("com/su"));
+    }
+
+    @Test
+    public void hasPrefix_emptyTree_returnsFalse() {
+        PrefixTree prefixTree = new PrefixTree(Collections.emptyList());
+        Assert.assertFalse(prefixTree.hasPrefix("a"));
+    }
+
+}

--- a/vaadin-spring/src/test/java/com/vaadin/flow/spring/PrefixTreeTest.java
+++ b/vaadin-spring/src/test/java/com/vaadin/flow/spring/PrefixTreeTest.java
@@ -33,7 +33,7 @@ public class PrefixTreeTest {
     }
 
     @Test
-    public void hasPrefix_containsPrefix_returnsFalse() {
+    public void hasPrefix_doesNotContainPrefix_returnsFalse() {
         PrefixTree prefixTree = new PrefixTree(
                 Arrays.asList("com/sun", "antlr", "ch/quos/logback"));
         Assert.assertFalse(prefixTree.hasPrefix(""));


### PR DESCRIPTION
Extend the default class scanning exclusion list to JDK and IDE classes.
Use prefix tree for faster lookups in long exclusion/inclusion lists.
Fixes #571.
