### PR TITLE
Added Spring Data helper class

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,11 @@
                 <version>${vaadin.flow.version}</version>
             </dependency>
             <dependency>
+                <groupId>com.vaadin</groupId>
+                <artifactId>flow-data</artifactId>
+                <version>${vaadin.flow.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-core</artifactId>
                 <version>${mockito.version}</version>

--- a/vaadin-spring/pom.xml
+++ b/vaadin-spring/pom.xml
@@ -67,7 +67,17 @@
             <artifactId>spring-boot-autoconfigure-processor</artifactId>
             <optional>true</optional>
         </dependency>
-
+        <dependency>
+            <groupId>org.springframework.data</groupId>
+            <artifactId>spring-data-commons</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>flow-data</artifactId>
+            <optional>true</optional>
+        </dependency>
+        
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-test</artifactId>

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/data/VaadinSpringDataHelpers.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/data/VaadinSpringDataHelpers.java
@@ -36,7 +36,7 @@ public interface VaadinSpringDataHelpers {
      * component to a Spring Data based back-end. The method expects Vaadin sort 
      * data to include the property name.
      *
-     * @param vaadinQuery the Vaadin Query object passed by he component
+     * @param vaadinQuery the Vaadin Query object passed by the component
      * @return the Sort object that can be passed for Spring Data based back-end
      */
     static Sort toSpringDataSort(Query<?, ?> vaadinQuery) {

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/data/VaadinSpringDataHelpers.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/data/VaadinSpringDataHelpers.java
@@ -36,16 +36,17 @@ public class VaadinSpringDataHelpers implements Serializable {
      * component to a Spring Data based back-end. The method expects Vaadin sort 
      * data to include the property name.
      *
-     * @param vaadinQuery
-     * @return
+     * @param vaadinQuery the Vaadin Query object passed by he component
+     * @return the Sort object that can be passed for Spring Data based back-end
      */
-    public static Sort toSpringDataSort(Query<?, Void> vaadinQuery) {
-        Sort springDataSort = Sort.by(vaadinQuery.getSortOrders().stream()
+    public static Sort toSpringDataSort(Query<?, ?> vaadinQuery) {
+        return Sort.by(vaadinQuery.getSortOrders().stream()
                 .map(
                         so -> so.getDirection() == SortDirection.ASCENDING
                         ? Order.asc(so.getSorted())
                         : Order.desc(so.getSorted()))
-                .collect(Collectors.toList()));
-        return springDataSort;
+                .collect(Collectors.toList())
+        );
     }
+
 }

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/data/VaadinSpringDataHelpers.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/data/VaadinSpringDataHelpers.java
@@ -23,11 +23,11 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Sort.Order;
 
 /**
- * This class contains helper methods to work with Spring Data based back-ends
+ * Contains helper methods to work with Spring Data based back-ends
  * and Vaadin components.
  */
-public class VaadinSpringDataHelpers implements Serializable {
-
+public interface VaadinSpringDataHelpers {
+    
     /**
      * Translates given Query object from a Vaadin component to Spring Data Sort
      * object.
@@ -39,7 +39,7 @@ public class VaadinSpringDataHelpers implements Serializable {
      * @param vaadinQuery the Vaadin Query object passed by he component
      * @return the Sort object that can be passed for Spring Data based back-end
      */
-    public static Sort toSpringDataSort(Query<?, ?> vaadinQuery) {
+    static Sort toSpringDataSort(Query<?, ?> vaadinQuery) {
         return Sort.by(vaadinQuery.getSortOrders().stream()
                 .map(
                         so -> so.getDirection() == SortDirection.ASCENDING

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/data/VaadinSpringDataHelpers.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/data/VaadinSpringDataHelpers.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2000-2020 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.spring.data;
+
+import com.vaadin.flow.data.provider.Query;
+import com.vaadin.flow.data.provider.SortDirection;
+import java.io.Serializable;
+import java.util.stream.Collectors;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Order;
+
+/**
+ * This class contains helper methods to work with Spring Data based back-ends
+ * and Vaadin components.
+ */
+public class VaadinSpringDataHelpers implements Serializable {
+
+    /**
+     * Translates given Query object from a Vaadin component to Spring Data Sort
+     * object.
+     * <p>
+     * Can be used as a helper when making a lazy data binding from a Vaadin
+     * component to a Spring Data based back-end. The method expects Vaadin sort 
+     * data to include the property name.
+     *
+     * @param vaadinQuery
+     * @return
+     */
+    public static Sort toSpringDataSort(Query<?, Void> vaadinQuery) {
+        Sort springDataSort = Sort.by(vaadinQuery.getSortOrders().stream()
+                .map(
+                        so -> so.getDirection() == SortDirection.ASCENDING
+                        ? Order.asc(so.getSorted())
+                        : Order.desc(so.getSorted()))
+                .collect(Collectors.toList()));
+        return springDataSort;
+    }
+}

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/data/VaadinSpringDataHelpers.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/data/VaadinSpringDataHelpers.java
@@ -26,7 +26,7 @@ import org.springframework.data.domain.Sort.Order;
  * Contains helper methods to work with Spring Data based back-ends
  * and Vaadin components.
  */
-public interface VaadinSpringDataHelpers {
+public interface VaadinSpringDataHelpers extends Serializable {
     
     /**
      * Translates given Query object from a Vaadin component to Spring Data Sort


### PR DESCRIPTION
The class contains just one method to make it easier to convert Vaadin sort hints from Query object to Sprind Data Sort, which is used by many backend implementations.

closes #643 