### PR TITLE
chore: Update Flow version to 5.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
 
         <!-- These are typically overridden with BOMs -->
-        <vaadin.flow.version>4.0-SNAPSHOT</vaadin.flow.version>
+        <vaadin.flow.version>5.0-SNAPSHOT</vaadin.flow.version>
         <spring-boot.version>2.2.0.RELEASE</spring-boot.version>
 
         <!-- Additional manifest fields -->


### PR DESCRIPTION
As the master Flow is at `5.0-SNAPSHOT`, this change updates the version in `pom.xml` accordingly.