### PR TITLE
Fix regression with add-on customized RouteNotFoundError subclass

### DIFF
--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinServletContextInitializer.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinServletContextInitializer.java
@@ -293,15 +293,13 @@ public class VaadinServletContextInitializer
                     .getInstance(new VaadinServletContext(
                             event.getServletContext()));
 
-            Stream<Class<? extends Component>> hasErrorComponents = findBySuperType(
+            Set<Class<? extends Component>> errorComponents = findBySuperType(
                     getErrorParameterPackages(), HasErrorParameter.class)
                             .filter(Component.class::isAssignableFrom)
                             // Replace Flow default with custom version for Spring
                             .filter(clazz -> clazz != RouteNotFoundError.class)
-                            .map(clazz -> (Class<? extends Component>) clazz);
-            final Set<Class<? extends Component>> errorComponents =
-                    hasErrorComponents.collect(Collectors.toSet());
-
+                            .map(clazz -> (Class<? extends Component>) clazz)
+                    .collect(Collectors.toSet());
             if (errorComponents.stream().noneMatch(RouteNotFoundError.class::isAssignableFrom)) {
                 errorComponents.add(SpringRouteNotFoundError.class);
             }

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/router/SpringRouteNotFoundError.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/router/SpringRouteNotFoundError.java
@@ -12,17 +12,18 @@ public class SpringRouteNotFoundError extends RouteNotFoundError {
             ErrorParameter<NotFoundException> parameter) {
         int retval = super.setErrorParameter(event, parameter);
 
-        // Alert user about potential issue with Spring Boot Devtools losing
-        // routes https://github.com/spring-projects/spring-boot/issues/19543
-        String customMessage = "<span>When using Spring Boot Devtools with "
-                + "automatic reload, please note that routes can sometimes be "
-                + "lost due to a <a href ='https://github.com/spring-projects/spring-boot/issues/19543'>"
-                + "compilation race condition</a>. See "
-                + "<a href='https://vaadin.com/docs/flow/workflow/setup-live-reload-springboot.html'>"
-                + "the documentation</a> for further workarounds and other "
-                + "live reload alternatives.";
-        getElement().appendChild(new Html(customMessage).getElement());
-
+        if (!event.getUI().getSession().getConfiguration().isProductionMode()) {
+            // Alert user about potential issue with Spring Boot Devtools losing
+            // routes https://github.com/spring-projects/spring-boot/issues/19543
+            String customMessage = "<span>When using Spring Boot Devtools with "
+                    + "automatic reload, please note that routes can sometimes be "
+                    + "lost due to a <a href ='https://github.com/spring-projects/spring-boot/issues/19543'>"
+                    + "compilation race condition</a>. See "
+                    + "<a href='https://vaadin.com/docs/flow/workflow/setup-live-reload-springboot.html'>"
+                    + "the documentation</a> for further workarounds and other "
+                    + "live reload alternatives.";
+            getElement().appendChild(new Html(customMessage).getElement());
+        }
         return retval;
     }
 }


### PR DESCRIPTION
A regression in #655 caused Flow to throw an exception when validating that the route registry had at most one component mapped to `com.vaadin.flow.router.NotFoundException`. Replace `RouteNotFoundError` from Flow with `SpringRouteNotFoundError` instead of adding it when setting up route registry. Custom exception views can inherit from either default.