### PR TITLE
fix: custom pushURL failed with non-root mapping

### DIFF
--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/SpringBootAutoConfiguration.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/SpringBootAutoConfiguration.java
@@ -76,9 +76,6 @@ public class SpringBootAutoConfiguration {
         boolean rootMapping = RootMappedCondition.isRootMapping(mapping);
         if (rootMapping) {
             mapping = VaadinServletConfiguration.VAADIN_SERVLET_MAPPING;
-            initParameters.put(Constants.SERVLET_PARAMETER_PUSH_URL,
-                    VaadinMVCWebAppInitializer
-                            .makeContextRelative(mapping.replace("*", "")));
         }
         ServletRegistrationBean<SpringServlet> registration = new ServletRegistrationBean<>(
                 new SpringServlet(context, rootMapping), mapping);

--- a/vaadin-spring/src/test/java/com/vaadin/flow/spring/instantiator/SpringInstantiatorTest.java
+++ b/vaadin-spring/src/test/java/com/vaadin/flow/spring/instantiator/SpringInstantiatorTest.java
@@ -158,8 +158,13 @@ public class SpringInstantiatorTest {
     }
 
     public static VaadinServletService getService(ApplicationContext context,
-            Properties configProperties) throws ServletException {
-        SpringServlet servlet = new SpringServlet(context, false) {
+            Properties configProperties ) throws ServletException {
+        return getService(context, configProperties, false);
+    }
+
+    public static VaadinServletService getService(ApplicationContext context,
+            Properties configProperties, boolean rootMapping) throws ServletException {
+        SpringServlet servlet = new SpringServlet(context, rootMapping) {
             @Override
             protected DeploymentConfiguration createDeploymentConfiguration(
                     Properties initParameters) {

--- a/vaadin-spring/src/test/java/com/vaadin/flow/spring/service/SpringServletTest.java
+++ b/vaadin-spring/src/test/java/com/vaadin/flow/spring/service/SpringServletTest.java
@@ -33,8 +33,7 @@ import com.vaadin.flow.shared.communication.PushMode;
 import com.vaadin.flow.spring.instantiator.SpringInstantiatorTest;
 
 @RunWith(SpringRunner.class)
-@SpringBootTest(properties = { "vaadin.push-mode=MANUAL",
-        "vaadin.push-u-r-l=someUrl" })
+@SpringBootTest(properties = { "vaadin.push-mode=MANUAL" })
 @Import(TestServletConfiguration.class)
 public class SpringServletTest {
 
@@ -48,17 +47,47 @@ public class SpringServletTest {
                 new Properties());
         PushMode pushMode = service.getDeploymentConfiguration().getPushMode();
         Assert.assertEquals(PushMode.MANUAL, pushMode);
+    }
 
-        Assert.assertEquals("someUrl",
+    @Test
+    public void pushURL_rootMapping_isPrefixedWithContextVaadinMapping()
+            throws ServletException {
+        VaadinService service = SpringInstantiatorTest.getService(context,
+                new Properties(), true);
+        Assert.assertEquals("context://vaadinServlet/",
                 service.getDeploymentConfiguration().getPushURL());
     }
 
     @Test
-    public void customPushUrl_rootMapping_isPrefixedWithContextVaadinMapping()
+    public void pushURL_rootMappingAndCustomURLWithoutPrecedingSlash_isPrefixedWithContextVaadinMapping()
             throws ServletException {
+        final Properties configProperties = new Properties();
+        configProperties.setProperty("pushURL", "customUrl");
         VaadinService service = SpringInstantiatorTest.getService(context,
-                new Properties(), true);
-        Assert.assertEquals("context://vaadinServlet/someUrl",
+                configProperties, true);
+        Assert.assertEquals("context://vaadinServlet/customUrl",
+                service.getDeploymentConfiguration().getPushURL());
+    }
+
+    @Test
+    public void pushURL_rootMappingAndCustomURLWithPrecedingSlash_isPrefixedWithContextVaadinMapping()
+            throws ServletException {
+        final Properties configProperties = new Properties();
+        configProperties.setProperty("pushURL", "/customUrl");
+        VaadinService service = SpringInstantiatorTest.getService(context,
+                configProperties, true);
+        Assert.assertEquals("context://vaadinServlet/customUrl",
+                service.getDeploymentConfiguration().getPushURL());
+    }
+
+    @Test
+    public void pushURL_rootMappingAndCustomURLWithVaadinServletPrefix_isNotAdditionallyPrefixed()
+            throws ServletException {
+        final Properties properties = new Properties();
+        properties.setProperty("pushURL", "/vaadinServlet/customUrl");
+        VaadinService service = SpringInstantiatorTest.getService(context,
+                properties, true);
+        Assert.assertEquals("context://vaadinServlet/customUrl",
                 service.getDeploymentConfiguration().getPushURL());
     }
 }

--- a/vaadin-spring/src/test/java/com/vaadin/flow/spring/service/SpringServletTest.java
+++ b/vaadin-spring/src/test/java/com/vaadin/flow/spring/service/SpringServletTest.java
@@ -42,7 +42,7 @@ public class SpringServletTest {
     private ApplicationContext context;
 
     @Test
-    public void readUniformNameProperty_propertyNameContansDash_propertyNameIsConvertedToCamelCaseAndReadProperly()
+    public void readUniformNameProperty_propertyNameContainsDash_propertyNameIsConvertedToCamelCaseAndReadProperly()
             throws ServletException {
         VaadinService service = SpringInstantiatorTest.getService(context,
                 new Properties());
@@ -50,6 +50,15 @@ public class SpringServletTest {
         Assert.assertEquals(PushMode.MANUAL, pushMode);
 
         Assert.assertEquals("someUrl",
+                service.getDeploymentConfiguration().getPushURL());
+    }
+
+    @Test
+    public void customPushUrl_rootMapping_isPrefixedWithContextVaadinMapping()
+            throws ServletException {
+        VaadinService service = SpringInstantiatorTest.getService(context,
+                new Properties(), true);
+        Assert.assertEquals("context://vaadinServlet/someUrl",
                 service.getDeploymentConfiguration().getPushURL());
     }
 }


### PR DESCRIPTION
When mapping was `/*`, `SpringBootAutoConfiguration` updated init parameter `pushURL` for `SpringServlet` but this was overridden later if custom `pushURL` was provided by user. Fixed by moving the push path update logic to just before deployment config is created.
Fixes vaadin/flow#9077.