### PR TITLE
chore: bump version to 15.0 for v18

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     </parent>
 
     <artifactId>vaadin-spring-parent</artifactId>
-    <version>14.0-SNAPSHOT</version>
+    <version>15.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>vaadin-spring-parent</name>

--- a/vaadin-spring-tests/dummy-module/pom.xml
+++ b/vaadin-spring-tests/dummy-module/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-spring-tests</artifactId>
-        <version>14.0-SNAPSHOT</version>
+        <version>15.0-SNAPSHOT</version>
     </parent>
     <artifactId>dummy-module</artifactId>
     <name>Keep this module as the last one in the list</name>

--- a/vaadin-spring-tests/pom.xml
+++ b/vaadin-spring-tests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-spring-parent</artifactId>
-        <version>14.0-SNAPSHOT</version>
+        <version>15.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-spring-tests</artifactId>
     <name>Vaadin Spring tests</name>

--- a/vaadin-spring-tests/test-spring-boot-contextpath/pom.xml
+++ b/vaadin-spring-tests/test-spring-boot-contextpath/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-spring-tests</artifactId>
-        <version>14.0-SNAPSHOT</version>
+        <version>15.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-test-spring-boot-contextpath</artifactId>
     <name>Vaadin Spring Boot integration tests when deployed using a context path</name>

--- a/vaadin-spring-tests/test-spring-boot-only-prepare/pom.xml
+++ b/vaadin-spring-tests/test-spring-boot-only-prepare/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-spring-tests</artifactId>
-        <version>14.0-SNAPSHOT</version>
+        <version>15.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-test-spring-boot-prepare</artifactId>
     <name>Vaadin Spring Boot integration tests with only prepare goal</name>

--- a/vaadin-spring-tests/test-spring-boot-scan/pom.xml
+++ b/vaadin-spring-tests/test-spring-boot-scan/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-spring-tests</artifactId>
-        <version>14.0-SNAPSHOT</version>
+        <version>15.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-test-spring-boot-scan</artifactId>
     <name>Vaadin Spring Boot integration tests with custom packages to scan</name>

--- a/vaadin-spring-tests/test-spring-boot/pom.xml
+++ b/vaadin-spring-tests/test-spring-boot/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-spring-tests</artifactId>
-        <version>14.0-SNAPSHOT</version>
+        <version>15.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-test-spring-boot</artifactId>
     <name>Vaadin Spring Boot integration tests</name>

--- a/vaadin-spring-tests/test-spring-common/pom.xml
+++ b/vaadin-spring-tests/test-spring-common/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-spring-tests</artifactId>
-        <version>14.0-SNAPSHOT</version>
+        <version>15.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-test-spring-common</artifactId>
     <name>Flow Spring Common UI components</name>

--- a/vaadin-spring-tests/test-spring-war/pom.xml
+++ b/vaadin-spring-tests/test-spring-war/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-spring-tests</artifactId>
-        <version>14.0-SNAPSHOT</version>
+        <version>15.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-test-spring-war</artifactId>
     <name>Vaadin Spring Boot deployable integration tests</name>

--- a/vaadin-spring-tests/test-spring-white-list/pom.xml
+++ b/vaadin-spring-tests/test-spring-white-list/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-spring-tests</artifactId>
-        <version>14.0-SNAPSHOT</version>
+        <version>15.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-test-spring-white-list</artifactId>
 

--- a/vaadin-spring-tests/test-ts-services-custom-client/pom.xml
+++ b/vaadin-spring-tests/test-ts-services-custom-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-spring-tests</artifactId>
-        <version>14.0-SNAPSHOT</version>
+        <version>15.0-SNAPSHOT</version>
     </parent>
     <artifactId>test-ts-services-custom-client</artifactId>
     <name>Integration tests for V15+ endpoints (custom Connect client)</name>

--- a/vaadin-spring-tests/test-ts-services/pom.xml
+++ b/vaadin-spring-tests/test-ts-services/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-spring-tests</artifactId>
-        <version>14.0-SNAPSHOT</version>
+        <version>15.0-SNAPSHOT</version>
     </parent>
     <artifactId>test-ts-services</artifactId>
     <name>Integration tests for V15+ endpoints</name>

--- a/vaadin-spring/pom.xml
+++ b/vaadin-spring/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-spring-parent</artifactId>
-        <version>14.0-SNAPSHOT</version>
+        <version>15.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>vaadin-spring</artifactId>


### PR DESCRIPTION
Needed because Flow version has bumped a major and there are significant
changes. Flow version used in build is already 5.0-SNAPSHOT.