### PR TITLE
fix: Fallback chunk is now loaded in production mode

### DIFF
--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/SpringServlet.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/SpringServlet.java
@@ -123,8 +123,7 @@ public class SpringServlet extends VaadinServlet {
     @Override
     protected DeploymentConfiguration createDeploymentConfiguration(
             Properties initParameters) {
-        Properties properties = new Properties(initParameters);
-        config(properties);
+        Properties properties = config(initParameters);
         if (rootMapping) {
             // in the case of root mapping, push requests should go to
             // /vaadinServlet/pushUrl
@@ -157,14 +156,19 @@ public class SpringServlet extends VaadinServlet {
         return request;
     }
 
-    private void config(Properties properties) {
-        setProperties(PROPERTY_NAMES, properties);
-    }
-
-    private void setProperties(List<String> propertyNames,
-            Properties properties) {
-        propertyNames.stream()
+    private Properties config(Properties initParameters) {
+        Properties properties = new Properties(initParameters);
+        PROPERTY_NAMES
                 .forEach(property -> setProperty(property, properties));
+
+        // transfer non-string init parameters (such as
+        // DeploymentConfigurationFactory.FALLBACK_CHUNK)
+        initParameters.forEach((key, value) -> {
+            if (!(key instanceof String)) {
+                properties.put(key, value);
+            }
+        });
+        return properties;
     }
 
     private void setProperty(String property, Properties properties) {

--- a/vaadin-spring/src/test/java/com/vaadin/flow/spring/service/SpringServletTest.java
+++ b/vaadin-spring/src/test/java/com/vaadin/flow/spring/service/SpringServletTest.java
@@ -105,7 +105,7 @@ public class SpringServletTest {
                 fallbackChunk);
         VaadinService service = SpringInstantiatorTest.getService(context,
                 properties, true);
-        Assert.assertEquals(fallbackChunk,
+        Assert.assertSame(fallbackChunk,
                 service.getDeploymentConfiguration().getInitParameters()
                         .get(DeploymentConfigurationFactory.FALLBACK_CHUNK));
     }

--- a/vaadin-spring/src/test/java/com/vaadin/flow/spring/service/SpringServletTest.java
+++ b/vaadin-spring/src/test/java/com/vaadin/flow/spring/service/SpringServletTest.java
@@ -17,6 +17,7 @@ package com.vaadin.flow.spring.service;
 
 import javax.servlet.ServletException;
 
+import java.util.Collections;
 import java.util.Properties;
 
 import org.junit.Assert;
@@ -28,7 +29,9 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.junit4.SpringRunner;
 
+import com.vaadin.flow.server.DeploymentConfigurationFactory;
 import com.vaadin.flow.server.VaadinService;
+import com.vaadin.flow.server.frontend.FallbackChunk;
 import com.vaadin.flow.shared.communication.PushMode;
 import com.vaadin.flow.spring.instantiator.SpringInstantiatorTest;
 
@@ -89,5 +92,21 @@ public class SpringServletTest {
                 properties, true);
         Assert.assertEquals("context://vaadinServlet/customUrl",
                 service.getDeploymentConfiguration().getPushURL());
+    }
+
+    // #662
+    @Test
+    public void fallbackChunk_givenInInitParameter_passedOnToDeploymentConfiguration()
+            throws ServletException {
+        FallbackChunk fallbackChunk = new FallbackChunk(Collections.emptyList(),
+                Collections.emptyList());
+        final Properties properties = new Properties();
+        properties.put(DeploymentConfigurationFactory.FALLBACK_CHUNK,
+                fallbackChunk);
+        VaadinService service = SpringInstantiatorTest.getService(context,
+                properties, true);
+        Assert.assertEquals(fallbackChunk,
+                service.getDeploymentConfiguration().getInitParameters()
+                        .get(DeploymentConfigurationFactory.FALLBACK_CHUNK));
     }
 }


### PR DESCRIPTION
Non-string init parameter (`DeploymentConfigurationFactory.FALLBACK_CHUNK`)  in `Properties`object was lost in the Spring properties mapping.

Fixes #662.