### PR TITLE
Update test module versions and push URL handling when already prefixed `context://` DON'T SQUASH

### DIFF
--- a/vaadin-spring-tests/test-spring-boot-undertow/pom.xml
+++ b/vaadin-spring-tests/test-spring-boot-undertow/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-spring-tests</artifactId>
-        <version>14.0-SNAPSHOT</version>
+        <version>15.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-test-spring-boot-undertow</artifactId>
     <name>Vaadin Spring Boot integration tests when running on Undertow</name>

--- a/vaadin-spring-tests/test-spring/pom.xml
+++ b/vaadin-spring-tests/test-spring/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-spring-tests</artifactId>
-        <version>14.0-SNAPSHOT</version>
+        <version>15.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-test-spring</artifactId>
     <name>Flow Spring deployable integration tests</name>

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/SpringServlet.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/SpringServlet.java
@@ -134,6 +134,7 @@ public class SpringServlet extends VaadinServlet {
             }
             final String mapping = VaadinServletConfiguration.VAADIN_SERVLET_MAPPING
                     .replace("/*", "");
+            customPushUrl = customPushUrl.replaceFirst("context://", "/");
             customPushUrl = customPushUrl.replaceFirst(Pattern.quote(mapping),
                     ""); // if workaround "/vaadinServlet/myCustomUrl" used
             customPushUrl = customPushUrl.replaceFirst("^/","");

--- a/vaadin-spring/src/test/java/com/vaadin/flow/spring/service/SpringServletTest.java
+++ b/vaadin-spring/src/test/java/com/vaadin/flow/spring/service/SpringServletTest.java
@@ -84,6 +84,17 @@ public class SpringServletTest {
     }
 
     @Test
+    public void pushURL_rootMappingAndCustomURLWithContextVaadinServletPrefix_isNotAdditionallyPrefixed()
+            throws ServletException {
+        final Properties properties = new Properties();
+        properties.setProperty("pushURL", "context://vaadinServlet/customUrl");
+        VaadinService service = SpringInstantiatorTest.getService(context,
+                properties, true);
+        Assert.assertEquals("context://vaadinServlet/customUrl",
+                service.getDeploymentConfiguration().getPushURL());
+    }
+
+    @Test
     public void pushURL_rootMappingAndCustomURLWithVaadinServletPrefix_isNotAdditionallyPrefixed()
             throws ServletException {
         final Properties properties = new Properties();


### PR DESCRIPTION
Updated two remaining test modules to 15.0-SNAPSHOT. Because of running against 14.0-SNAPSHOT I missed one regression in (if pushURL already had prefix `context://` it was added again), this is now fixed. 