### PR TITLE
fix: add org/eclipse/persistence to default exclusions

### DIFF
--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinServletContextInitializer.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinServletContextInitializer.java
@@ -120,9 +120,10 @@ public class VaadinServletContextInitializer
             "com/h2database", "com/helger", "com/vaadin/external/atmosphere",
             "com/vaadin/webjar", "junit", "net/bytebuddy", "org/apache",
             "org/aspectj", "org/bouncycastle", "org/dom4j", "org/easymock",
-            "org/hamcrest", "org/hibernate", "org/javassist", "org/jboss",
-            "org/jsoup", "org/seleniumhq", "org/slf4j", "org/atmosphere",
-            "org/springframework", "org/webjars/bowergithub", "org/yaml",
+            "org/eclipse/persistence", "org/hamcrest", "org/hibernate",
+            "org/javassist", "org/jboss", "org/jsoup", "org/seleniumhq",
+            "org/slf4j", "org/atmosphere", "org/springframework", 
+            "org/webjars/bowergithub", "org/yaml",
 
             "java/", "javax/", "javafx/", "com/sun/", "oracle/deploy",
             "oracle/javafx", "oracle/jrockit", "oracle/jvm", "oracle/net",


### PR DESCRIPTION
Based on community feedback. This is a common transitive dependency 
that easily adds tens of seconds of startups time.