### PR TITLE
fix: add org/eclipse/persistence to default exclusions (#674)

### DIFF
--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinServletContextInitializer.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinServletContextInitializer.java
@@ -113,9 +113,10 @@ public class VaadinServletContextInitializer
             "com/h2database", "com/helger", "com/vaadin/external/atmosphere",
             "com/vaadin/webjar", "junit", "net/bytebuddy", "org/apache",
             "org/aspectj", "org/bouncycastle", "org/dom4j", "org/easymock",
-            "org/hamcrest", "org/hibernate", "org/javassist", "org/jboss",
-            "org/jsoup", "org/seleniumhq", "org/slf4j", "org/atmosphere",
-            "org/springframework", "org/webjars/bowergithub", "org/yaml",
+            "org/eclipse/persistence", "org/hamcrest", "org/hibernate",
+            "org/javassist", "org/jboss", "org/jsoup", "org/seleniumhq",
+            "org/slf4j", "org/atmosphere", "org/springframework", 
+            "org/webjars/bowergithub", "org/yaml",
 
             "java/", "javax/", "javafx/", "com/sun/", "oracle/deploy",
             "oracle/javafx", "oracle/jrockit", "oracle/jvm", "oracle/net",


### PR DESCRIPTION
Based on community feedback (https://vaadin.com/forum/thread/18465049/long-startup-time).
This is a common transitive dependency that easily adds tens of second of scan time.