### PR TITLE
Stop showing devtools reload msg SB >= 2.4 (#685)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,15 +45,15 @@
 
         <!-- These are typically overridden with BOMs -->
         <vaadin.flow.version>5.0-SNAPSHOT</vaadin.flow.version>
-        <spring-boot.version>2.2.0.RELEASE</spring-boot.version>
+        <spring-boot.version>2.4.0</spring-boot.version>
 
         <!-- Additional manifest fields -->
         <Vaadin-License-Title>Apache License 2.0</Vaadin-License-Title>
 
         <junit.version>4.12</junit.version>
         <maven.clean.plugin.version>3.0.0</maven.clean.plugin.version>
-        <mockito.version>3.1.0</mockito.version>
-        <powermock.version>2.0.7</powermock.version>
+        <mockito.version>3.6.0</mockito.version>
+        <powermock.version>2.0.9</powermock.version>
     </properties>
 
     <dependencyManagement>

--- a/vaadin-spring/pom.xml
+++ b/vaadin-spring/pom.xml
@@ -100,7 +100,7 @@
 
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
+            <artifactId>mockito-inline</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/router/SpringRouteNotFoundError.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/router/SpringRouteNotFoundError.java
@@ -5,24 +5,35 @@ import com.vaadin.flow.router.BeforeEnterEvent;
 import com.vaadin.flow.router.ErrorParameter;
 import com.vaadin.flow.router.NotFoundException;
 import com.vaadin.flow.router.RouteNotFoundError;
+import com.vaadin.flow.server.frontend.FrontendVersion;
+import org.springframework.boot.SpringBootVersion;
 
 public class SpringRouteNotFoundError extends RouteNotFoundError {
+
     @Override
     public int setErrorParameter(BeforeEnterEvent event,
             ErrorParameter<NotFoundException> parameter) {
         int retval = super.setErrorParameter(event, parameter);
-
         if (!event.getUI().getSession().getConfiguration().isProductionMode()) {
             // Alert user about potential issue with Spring Boot Devtools losing
             // routes https://github.com/spring-projects/spring-boot/issues/19543
-            String customMessage = "<span>When using Spring Boot Devtools with "
-                    + "automatic reload, please note that routes can sometimes be "
-                    + "lost due to a <a href ='https://github.com/spring-projects/spring-boot/issues/19543'>"
-                    + "compilation race condition</a>. See "
-                    + "<a href='https://vaadin.com/docs/flow/workflow/setup-live-reload-springboot.html'>"
-                    + "the documentation</a> for further workarounds and other "
-                    + "live reload alternatives.";
-            getElement().appendChild(new Html(customMessage).getElement());
+            // This has been fixed since Spring Boot 2.4.0
+            String springBootVersion = SpringBootVersion.getVersion();
+            if (springBootVersion == null || springBootVersion.isEmpty()) {
+                return retval;
+            }
+            // the version is e.g. "2.2.0.RELEASE" or "2.4.0" ...
+            FrontendVersion version = new FrontendVersion(springBootVersion);
+            if (version.isOlderThan(new FrontendVersion(2, 4, 0))) {
+                String customMessage = "<span>When using Spring Boot Devtools with "
+                        + "automatic reload, please note that routes can sometimes be "
+                        + "lost due to a <a href ='https://github.com/spring-projects/spring-boot/issues/19543'>"
+                        + "compilation race condition</a>. See "
+                        + "<a href='https://vaadin.com/docs/flow/workflow/setup-live-reload-springboot.html'>"
+                        + "the documentation</a> for further workarounds and other "
+                        + "live reload alternatives.";
+                getElement().appendChild(new Html(customMessage).getElement());
+            }
         }
         return retval;
     }

--- a/vaadin-spring/src/test/java/com/vaadin/flow/spring/router/SpringRouteNotFoundErrorTest.java
+++ b/vaadin-spring/src/test/java/com/vaadin/flow/spring/router/SpringRouteNotFoundErrorTest.java
@@ -1,0 +1,110 @@
+package com.vaadin.flow.spring.router;
+
+import java.util.ArrayList;
+
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.function.DeploymentConfiguration;
+import com.vaadin.flow.router.BeforeEnterEvent;
+import com.vaadin.flow.router.ErrorParameter;
+import com.vaadin.flow.router.Location;
+import com.vaadin.flow.router.NotFoundException;
+import com.vaadin.flow.router.RouteNotFoundError;
+import com.vaadin.flow.router.Router;
+import com.vaadin.flow.server.RouteRegistry;
+import com.vaadin.flow.server.VaadinSession;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.springframework.boot.SpringBootVersion;
+
+import static org.mockito.Mockito.when;
+
+public class SpringRouteNotFoundErrorTest {
+
+    @Mock
+    private BeforeEnterEvent event;
+
+    @Mock
+    private ErrorParameter<NotFoundException> parameter;
+
+    @Mock
+    private UI ui;
+
+    @Mock
+    private VaadinSession session;
+
+    @Mock
+    private DeploymentConfiguration configuration;
+
+    @Mock
+    private Router router;
+
+    @Mock
+    private RouteRegistry registry;
+    private AutoCloseable autoCloseable;
+
+    @Before
+    public void setup() {
+        autoCloseable = MockitoAnnotations.openMocks(this);
+        when(event.getLocation()).thenReturn(new Location("foobar"));
+        when(parameter.hasCustomMessage()).thenReturn(false);
+        when(event.getUI()).thenReturn(ui);
+        when(ui.getSession()).thenReturn(session);
+        when(session.getConfiguration()).thenReturn(configuration);
+        when(configuration.isProductionMode()).thenReturn(false);
+        when(event.getSource()).thenReturn(router);
+        when(router.getRegistry()).thenReturn(registry);
+        when(registry.getRegisteredRoutes()).thenReturn(new ArrayList<>());
+    }
+
+    @After
+    public void teardown() throws Exception {
+        autoCloseable.close();
+    }
+
+    @Test
+    public void testRouteNotFoundError_bootVersionIsTwoFourOrNewer_noAddedMessageShown() {
+        final RouteNotFoundError normalErrorView = new RouteNotFoundError();
+        final SpringRouteNotFoundError springRouteNotFoundError = new SpringRouteNotFoundError();
+
+        normalErrorView.setErrorParameter(event, parameter);
+        // the project uses 2.4.0 at the time of writing this test, so it will
+        // not add the message
+        springRouteNotFoundError.setErrorParameter(event, parameter);
+
+        Assert.assertEquals("Invalid number of children", ((Long) normalErrorView.getChildren().count()).intValue(), ((Long) springRouteNotFoundError.getChildren().count()).intValue());
+    }
+
+    @Test
+    public void testRouteNotFoundError_bootVersionIsTwoTwoSomething_addedMessageShown() {
+        final RouteNotFoundError normalErrorView = new RouteNotFoundError();
+        final SpringRouteNotFoundError springRouteNotFoundError = new SpringRouteNotFoundError();
+
+        try (MockedStatic<SpringBootVersion> theMock = Mockito.mockStatic(SpringBootVersion.class)) {
+            theMock.when(SpringBootVersion::getVersion).thenReturn("2.2.0.RELEASE");
+
+            normalErrorView.setErrorParameter(event, parameter);
+            springRouteNotFoundError.setErrorParameter(event, parameter);
+
+            theMock.verify(SpringBootVersion::getVersion);
+        }
+        Assert.assertNotEquals("Invalid number of children", ((Long) normalErrorView.getChildren().count()).intValue(), ((Long) springRouteNotFoundError.getChildren().count()).intValue());
+    }
+
+    @Test
+    public void testRouteNotFoundError_productionMode_SpringVersionNotChecked() {
+        final SpringRouteNotFoundError springRouteNotFoundError = new SpringRouteNotFoundError();
+
+        try (MockedStatic<SpringBootVersion> theMock = Mockito.mockStatic(SpringBootVersion.class)) {
+            when(configuration.isProductionMode()).thenReturn(true);
+            theMock.when(SpringBootVersion::getVersion).then(AssertionError::new);
+            springRouteNotFoundError.setErrorParameter(event, parameter);
+            theMock.verifyNoInteractions();
+        }
+    }
+}


### PR DESCRIPTION
The issue has been fixed in Spring Boot 2.4.0.
Bumps the project version to Spring Boot 2.4.0.
Bumps Mockito to 3.6.0.
PowerMock is quite broken with never mockito versions and should be avoided.
It seems to be only used due to mocking private methods, which is questionable.