### PR TITLE
chore: add fusion-endpoint dependency for endpoint test modules

### DIFF
--- a/vaadin-spring-tests/test-ts-services-custom-client/pom.xml
+++ b/vaadin-spring-tests/test-ts-services-custom-client/pom.xml
@@ -27,6 +27,13 @@
                 </exclusion>
             </exclusions>
         </dependency>
+
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>fusion-endpoint</artifactId>
+            <version>${vaadin.flow.version}</version>
+        </dependency>
+        
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>

--- a/vaadin-spring-tests/test-ts-services/pom.xml
+++ b/vaadin-spring-tests/test-ts-services/pom.xml
@@ -33,6 +33,11 @@
             <version>${vaadin.flow.version}</version>
         </dependency>
         <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>fusion-endpoint</artifactId>
+            <version>${vaadin.flow.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>

--- a/vaadin-spring/src/test/java/com/vaadin/flow/spring/VaadinServletContextInitializerTest.java
+++ b/vaadin-spring/src/test/java/com/vaadin/flow/spring/VaadinServletContextInitializerTest.java
@@ -5,14 +5,13 @@ import javax.servlet.ServletContextEvent;
 import javax.servlet.ServletContextListener;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 
-import com.google.common.collect.Maps;
-import org.apache.commons.lang3.StringUtils;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -316,8 +315,7 @@ public class VaadinServletContextInitializerTest {
     }
 
     private void mockServletContext() {
-        final Map<String, Object> servletContextAttributesMap = Maps
-                .newHashMap();
+        final Map<String, Object> servletContextAttributesMap = new HashMap<>();
         Mockito.doAnswer(answer -> {
             String key = answer.getArgument(0, String.class);
             Object value = answer.getArgument(1, Object.class);
@@ -329,12 +327,12 @@ public class VaadinServletContextInitializerTest {
                 .thenAnswer(answer -> servletContextAttributesMap
                         .get(answer.getArgument(0, String.class)));
         Mockito.when(servletContext.getServletRegistrations())
-                .thenReturn(Maps.newHashMap());
+                .thenReturn(new HashMap<>());
     }
 
     private void mockEnvironment() {
-        Mockito.when(environment.resolveRequiredPlaceholders(StringUtils.EMPTY))
-                .thenReturn(StringUtils.EMPTY);
+        Mockito.when(environment.resolveRequiredPlaceholders(""))
+                .thenReturn("");
     }
 
     private void mockDeploymentConfiguration() {


### PR DESCRIPTION
Add fusion-endpoint dependency to endpoint testing modules.
Depends on https://github.com/vaadin/flow/pull/9499