### PR TITLE
chore: re-enable connect ITs

### DIFF
--- a/vaadin-spring-tests/test-ts-services-custom-client/src/test/java/com/vaadin/flow/connect/AppViewIT.java
+++ b/vaadin-spring-tests/test-ts-services-custom-client/src/test/java/com/vaadin/flow/connect/AppViewIT.java
@@ -19,7 +19,6 @@ import java.util.regex.Pattern;
 
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.support.ui.ExpectedConditions;
@@ -30,7 +29,6 @@ import com.vaadin.testbench.TestBenchElement;
 /**
  * Class for testing issues in a spring-boot container.
  */
-@Ignore("Ignored because of https://github.com/vaadin/flow/issues/9751")
 public class AppViewIT extends ChromeBrowserTest {
 
     private void openTestUrl(String url) {

--- a/vaadin-spring-tests/test-ts-services/src/test/java/com/vaadin/flow/connect/AppViewIT.java
+++ b/vaadin-spring-tests/test-ts-services/src/test/java/com/vaadin/flow/connect/AppViewIT.java
@@ -18,7 +18,6 @@ package com.vaadin.flow.connect;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
@@ -30,7 +29,6 @@ import com.vaadin.testbench.TestBenchElement;
 /**
  * Class for testing issues in a spring-boot container.
  */
-@Ignore("Ignored because of https://github.com/vaadin/flow/issues/9751")
 public class AppViewIT extends ChromeBrowserTest {
 
     private void openTestUrl(String url) {


### PR DESCRIPTION
Re-enable tests after fixing wrong "this" binding in Flow 
with loadingStarted/Finished.

See vaadin/flow#9751.