### PR TITLE
Cherry Picks from master to 16.0

### DIFF
--- a/vaadin-spring-tests/test-ts-services-custom-client/frontend/main-view.ts
+++ b/vaadin-spring-tests/test-ts-services-custom-client/frontend/main-view.ts
@@ -1,6 +1,7 @@
 import { css, customElement, html, LitElement, property } from 'lit-element';
 
 import * as appEndpoint from './generated/AppEndpoint';
+import {AppEndpoint} from "./generated/AppEndpoint";
 
 @customElement('main-view')
 export class MainView extends LitElement {
@@ -11,6 +12,7 @@ export class MainView extends LitElement {
   render() {
     return html`
       <button id="helloAnonymous" @click="${this.helloAnonymous}">endpoint helloAnonymous</button><br/>
+      <button id="helloAnonymousWrapper" @click="${this.helloAnonymousWrapper}">endpoint AppEndpoint.helloAnonymous</button><br/>
       <div id="content">${this.content}</div>
     `;
   }
@@ -18,6 +20,14 @@ export class MainView extends LitElement {
   async helloAnonymous() {
     try {
       this.content = await appEndpoint.helloAnonymous();
+    } catch (error) {
+      this.content = 'Error:' + error;
+    }
+  }
+
+  async helloAnonymousWrapper() {
+    try {
+      this.content = await AppEndpoint.helloAnonymous();
     } catch (error) {
       this.content = 'Error:' + error;
     }
@@ -34,3 +44,4 @@ export class MainView extends LitElement {
     ];
   }
 }
+

--- a/vaadin-spring-tests/test-ts-services-custom-client/src/test/java/com/vaadin/flow/connect/AppViewIT.java
+++ b/vaadin-spring-tests/test-ts-services-custom-client/src/test/java/com/vaadin/flow/connect/AppViewIT.java
@@ -64,6 +64,24 @@ public class AppViewIT extends ChromeBrowserTest {
     }
 
     @Test
+    public void should_requestAnonymously_endpoint_wrapper() {
+        TestBenchElement button = mainView.$(TestBenchElement.class)
+                .id("helloAnonymousWrapper");
+        button.click();
+
+        // Wait for the server connect response
+        waitUntil(ExpectedConditions.textToBePresentInElement(
+                mainView.$(TestBenchElement.class).id("content"),
+                "Hello, stranger!"), 25);
+
+        // verify that the custom Connect client works
+        waitUntil(
+                ExpectedConditions.textMatches(By.id("log"), Pattern.compile(
+                        "\\[LOG] AppEndpoint/helloAnonymous took \\d+ ms")),
+                25);
+    }
+
+    @Test
     public void should_requestAnonymously_after_logout() throws Exception {
         String originalCsrfToken = executeScript(
                 "return self.Vaadin.TypeScript.csrfToken").toString();

--- a/vaadin-spring-tests/test-ts-services/frontend/src/test-component.js
+++ b/vaadin-spring-tests/test-ts-services/frontend/src/test-component.js
@@ -2,6 +2,7 @@ import { PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { html } from '@polymer/polymer/lib/utils/html-tag.js';
 import * as appEndpoint from '../generated/AppEndpoint';
 import * as packagePrivateEndpoint from '../generated/PackagePrivateEndpoint';
+import {AppEndpoint} from "../generated/AppEndpoint";
 
 class TestComponent extends PolymerElement {
   static get template() {
@@ -9,6 +10,7 @@ class TestComponent extends PolymerElement {
         <button id="button">vaadin hello</button><br/>
         <button id="hello" on-click="hello">endpoint hello</button><br/>
         <button id="helloAnonymous" on-click="helloAnonymous">endpoint helloAnonymous</button><br/>
+        <button id="helloAnonymousWrapper" on-click="helloAnonymousWrapper">endpoint AppEndpoint.helloAnonymous</button><br/>
         <button id="echoWithOptional" on-click="echoWithOptional">endpoint echoWithOptional</button><br/>
         <button id="helloAdmin" on-click="helloAdmin">endpoint helloAdmin</button><br/>
         <button id="checkUser" on-click="checkUser">endpoint checkUser</button><br/>
@@ -45,6 +47,13 @@ class TestComponent extends PolymerElement {
         .helloAnonymous()
         .then(response => this.$.content.textContent = response)
         .catch(error => this.$.content.textContent = 'Error:' + error);
+  }
+
+  helloAnonymousWrapper(e) {
+      AppEndpoint
+          .helloAnonymous()
+          .then(response => this.$.content.textContent = response)
+          .catch(error => this.$.content.textContent = 'Error:' + error);
   }
 
   helloAnonymousFromPackagePrivateEndpoint(e) {

--- a/vaadin-spring-tests/test-ts-services/src/test/java/com/vaadin/flow/connect/AppViewIT.java
+++ b/vaadin-spring-tests/test-ts-services/src/test/java/com/vaadin/flow/connect/AppViewIT.java
@@ -63,7 +63,7 @@ public class AppViewIT extends ChromeBrowserTest {
 
     /**
      * Just a control test that assures that webcomponents is working.
-     * 
+     *
      * @throws Exception
      */
     @Test
@@ -90,6 +90,16 @@ public class AppViewIT extends ChromeBrowserTest {
     public void should_requestAnonymously_connect_service() throws Exception {
         WebElement button = testComponent.$(TestBenchElement.class)
                 .id("helloAnonymous");
+        button.click();
+
+        // Wait for the server connect response
+        verifyContent("Hello, stranger!");
+    }
+
+    @Test
+    public void should_requestAnonymously_endpoint_wrapper() throws Exception {
+        WebElement button = testComponent.$(TestBenchElement.class)
+                .id("helloAnonymousWrapper");
         button.click();
 
         // Wait for the server connect response


### PR DESCRIPTION
* test(TypeScript): add tests for endpoint class-like wrappers

Connected to vaadin/flow#7176
Depends on vaadin/flow#9972

* fix: uncomment import line for missing AppEndpoint

(cherry picked from commit 6db5bbf808a285e9bddb821af3e88b9acd695ad6)