### PR TITLE
fix: Run LookupServletContainerInitializer logic in Spring Boot case (#726)

### DIFF
--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinServletContextInitializer.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinServletContextInitializer.java
@@ -236,7 +236,13 @@ public class VaadinServletContextInitializer
             Set<Class<?>> classes = Stream.concat(
                     findByAnnotationOrSuperType(getLookupPackages(), appContext,
                             Collections.emptyList(), getServiceTypes()),
-                    Stream.of(SpringLookupInitializer.class))
+                    // LookupInitializer is necessary here: it allows
+                    // identify Spring boot as a regular Web container (and run
+                    // LookupServletContainerInitializer logic) even though
+                    // LookupInitializer will be ignored because there
+                    // is its subclass SpringLookupInitializer provided
+                    Stream.of(LookupInitializer.class,
+                            SpringLookupInitializer.class))
                     .collect(Collectors.toSet());
             process(classes, event.getServletContext());
         }


### PR DESCRIPTION
Run LookupServletContainerInitializer logic in Spring Boot case

(cherry picked from commit 3a5b76864ba2835479e183b9590ff0a6b52ed276)