### PR TITLE
refactor: update SecurityHelper.PUBLIC_VAADIN_URLS references

### DIFF
--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinSpringSecurity.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinSpringSecurity.java
@@ -25,7 +25,7 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 import org.springframework.security.web.util.matcher.OrRequestMatcher;
 import org.springframework.security.web.util.matcher.RequestMatcher;
-import com.vaadin.flow.internal.SecurityHelper;
+import com.vaadin.flow.server.HandlerHelper;
 
 /**
  * Helpers for Spring Security configuration of Vaadin applications.
@@ -67,7 +67,7 @@ public class VaadinSpringSecurity {
      */
     public static RequestMatcher getDefaultWebSecurityIgnoreMatcher() {
         return new OrRequestMatcher(Stream
-                .of(SecurityHelper.PUBLIC_VAADIN_URLS)
+                .of(HandlerHelper.getPublicResources())
                 .map(AntPathRequestMatcher::new)
                 .collect(Collectors.toList()));
     }


### PR DESCRIPTION
Due to flow #10534 PUBLIC_VAADIN_URLS
should be replaced with HelperHandler
alternative.