### PR TITLE
refactor: decouple Spring add-on and DevModeHandler

### DIFF
--- a/vaadin-spring-tests/test-mvc-without-endpoints/pom.xml
+++ b/vaadin-spring-tests/test-mvc-without-endpoints/pom.xml
@@ -29,6 +29,10 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-dev-server</artifactId>
+        </dependency>  
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>

--- a/vaadin-spring-tests/test-spring-boot-contextpath/pom.xml
+++ b/vaadin-spring-tests/test-spring-boot-contextpath/pom.xml
@@ -24,6 +24,11 @@
 
         <dependency>
             <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-dev-server</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.vaadin</groupId>
             <artifactId>vaadin-test-spring-common</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/vaadin-spring-tests/test-spring-boot-only-prepare/pom.xml
+++ b/vaadin-spring-tests/test-spring-boot-only-prepare/pom.xml
@@ -24,6 +24,11 @@
 
         <dependency>
             <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-dev-server</artifactId>
+        </dependency>  
+		
+        <dependency>
+            <groupId>com.vaadin</groupId>
             <artifactId>vaadin-test-spring-common</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/vaadin-spring-tests/test-spring-boot-scan/pom.xml
+++ b/vaadin-spring-tests/test-spring-boot-scan/pom.xml
@@ -25,6 +25,11 @@
 
         <dependency>
             <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-dev-server</artifactId>
+        </dependency>
+		
+        <dependency>
+            <groupId>com.vaadin</groupId>
             <artifactId>vaadin-test-spring-common</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/vaadin-spring-tests/test-spring-boot/pom.xml
+++ b/vaadin-spring-tests/test-spring-boot/pom.xml
@@ -24,6 +24,11 @@
 
         <dependency>
             <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-dev-server</artifactId>
+        </dependency>  
+		
+        <dependency>
+            <groupId>com.vaadin</groupId>
             <artifactId>vaadin-test-spring-common</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -31,7 +36,6 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
-
         </dependency>
 
         <dependency>

--- a/vaadin-spring-tests/test-spring-security-flow-contextpath/pom.xml
+++ b/vaadin-spring-tests/test-spring-security-flow-contextpath/pom.xml
@@ -21,6 +21,10 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-dev-server</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>

--- a/vaadin-spring-tests/test-spring-security-flow/pom.xml
+++ b/vaadin-spring-tests/test-spring-security-flow/pom.xml
@@ -21,6 +21,10 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-dev-server</artifactId>
+        </dependency>		
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>

--- a/vaadin-spring-tests/test-spring-security-fusion/pom.xml
+++ b/vaadin-spring-tests/test-spring-security-fusion/pom.xml
@@ -25,6 +25,10 @@
             <artifactId>fusion-endpoint</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-dev-server</artifactId>
+        </dependency>		
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>

--- a/vaadin-spring-tests/test-spring-war/pom.xml
+++ b/vaadin-spring-tests/test-spring-war/pom.xml
@@ -33,6 +33,11 @@
         </dependency>
 
         <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-dev-server</artifactId>
+        </dependency>  
+		
+        <dependency>
             <groupId>org.springframework.security.oauth</groupId>
             <artifactId>spring-security-oauth2</artifactId>
         </dependency>

--- a/vaadin-spring-tests/test-spring-white-list/pom.xml
+++ b/vaadin-spring-tests/test-spring-white-list/pom.xml
@@ -41,6 +41,11 @@
 
         <dependency>
             <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-dev-server</artifactId>
+        </dependency>  
+		
+        <dependency>
+            <groupId>com.vaadin</groupId>
             <artifactId>vaadin-button-flow</artifactId>
             <version>${vaadin.button.version}</version>
         </dependency>

--- a/vaadin-spring-tests/test-ts-services-custom-client/pom.xml
+++ b/vaadin-spring-tests/test-ts-services-custom-client/pom.xml
@@ -30,6 +30,11 @@
 
         <dependency>
             <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-dev-server</artifactId>
+        </dependency> 
+
+        <dependency>
+            <groupId>com.vaadin</groupId>
             <artifactId>fusion-endpoint</artifactId>
             <version>${vaadin.flow.version}</version>
         </dependency>

--- a/vaadin-spring-tests/test-ts-services/pom.xml
+++ b/vaadin-spring-tests/test-ts-services/pom.xml
@@ -29,6 +29,10 @@
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-dev-server</artifactId>
+        </dependency> 
+        <dependency>
+            <groupId>com.vaadin</groupId>
             <artifactId>flow-polymer-template</artifactId>
             <version>${vaadin.flow.version}</version>
         </dependency>


### PR DESCRIPTION
Instead of relying directly on DevModeHandler and DevModeInitializerImpl, use internal API. Required as DevModeHandler now resides in an optional dependency (`vaadin-dev-server`).

Part of vaadin/flow#10892
Depends on vaadin/flow#10969