### PR TITLE
fix: Make all public views available without login

### DIFF
--- a/vaadin-spring-tests/test-spring-security-flow/src/main/java/com/vaadin/flow/spring/flowsecurity/views/AnotherPublicView.java
+++ b/vaadin-spring-tests/test-spring-security-flow/src/main/java/com/vaadin/flow/spring/flowsecurity/views/AnotherPublicView.java
@@ -1,0 +1,24 @@
+package com.vaadin.flow.spring.flowsecurity.views;
+
+import com.vaadin.flow.component.html.H1;
+import com.vaadin.flow.component.orderedlayout.FlexLayout;
+import com.vaadin.flow.router.PageTitle;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.server.auth.AnonymousAllowed;
+
+@Route(value = "another", layout = MainView.class)
+@PageTitle("Another Public View")
+@AnonymousAllowed
+public class AnotherPublicView extends FlexLayout {
+
+    public AnotherPublicView() {
+        setFlexDirection(FlexDirection.COLUMN);
+        setHeightFull();
+
+        H1 header = new H1("Another public view for testing");
+        header.setId("header");
+        header.getStyle().set("text-align", "center");
+        add(header);
+    }
+
+}

--- a/vaadin-spring-tests/test-spring-security-flow/src/test/java/com/vaadin/flow/spring/flowsecurity/AppViewIT.java
+++ b/vaadin-spring-tests/test-spring-security-flow/src/test/java/com/vaadin/flow/spring/flowsecurity/AppViewIT.java
@@ -23,6 +23,7 @@ import org.junit.Test;
 public class AppViewIT extends ChromeBrowserTest {
 
     private static final String ROOT_PAGE_HEADER_TEXT = "Welcome to the Java Bank of Vaadin";
+    private static final String ANOTHER_PUBLIC_PAGE_HEADER_TEXT = "Another public view for testing";
     private static final int SERVER_PORT = 8888;
     private static final String USER_FULLNAME = "John the User";
     private static final String ADMIN_FULLNAME = "Emma the Admin";
@@ -107,6 +108,12 @@ public class AppViewIT extends ChromeBrowserTest {
     public void root_page_does_not_require_login() {
         open("");
         assertRootPageShown();
+    }
+
+    @Test
+    public void other_public_page_does_not_require_login() {
+        open("another");
+        assertAnotherPublicPageShown();
     }
 
     @Test
@@ -299,6 +306,12 @@ public class AppViewIT extends ChromeBrowserTest {
         waitUntil(drive -> $("h1").attribute("id", "header").exists());
         String headerText = $("h1").id("header").getText();
         Assert.assertEquals(ROOT_PAGE_HEADER_TEXT, headerText);
+    }
+
+    private void assertAnotherPublicPageShown() {
+        waitUntil(drive -> $("h1").attribute("id", "header").exists());
+        String headerText = $("h1").id("header").getText();
+        Assert.assertEquals(ANOTHER_PUBLIC_PAGE_HEADER_TEXT, headerText);
     }
 
     private void assertPrivatePageShown(String fullName) {

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/RequestUtil.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/RequestUtil.java
@@ -106,20 +106,30 @@ public class RequestUtil {
         return false;
     }
 
+    /**
+     * Checks whether the request targets a Flow route that is public, i.e.
+     * marked as @{@link AnonymousAllowed}.
+     *
+     * @param request
+     *            the servlet request
+     * @return {@code true} if the request is targeting an anonymous route,
+     *         {@code false} otherwise
+     */
     public boolean isAnonymousRoute(HttpServletRequest request) {
         String vaadinMapping = configurationProperties.getUrlMapping();
         String requestedPath = getRequestPathInsideContext(request);
-        if (requestedPath.startsWith("/")) {
-            // Requested path includes a beginning "/" but route mapping is done
-            // without one
-            requestedPath = requestedPath.substring(1);
-        }
         Optional<String> maybePath = HandlerHelper
                 .getPathIfInsideServlet(vaadinMapping, requestedPath);
         if (!maybePath.isPresent()) {
             return false;
         }
         String path = maybePath.get();
+        if (path.startsWith("/")) {
+            // Requested path includes a beginning "/" but route mapping is done
+            // without one
+            path = path.substring(1);
+        }
+
         SpringServlet servlet = springServletRegistration.getServlet();
         VaadinService service = servlet.getService();
         Router router = service.getRouter();

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/RequestUtil.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/RequestUtil.java
@@ -109,6 +109,11 @@ public class RequestUtil {
     public boolean isAnonymousRoute(HttpServletRequest request) {
         String vaadinMapping = configurationProperties.getUrlMapping();
         String requestedPath = getRequestPathInsideContext(request);
+        if (requestedPath.startsWith("/")) {
+            // Requested path includes a beginning "/" but route mapping is done
+            // without one
+            requestedPath = requestedPath.substring(1);
+        }
         Optional<String> maybePath = HandlerHelper
                 .getPathIfInsideServlet(vaadinMapping, requestedPath);
         if (!maybePath.isPresent()) {


### PR DESCRIPTION
Previously only a root mapped ("") view was available

Fixes https://github.com/vaadin/flow/issues/11355