### PR TITLE
test: add mobx dep via @NpmPackage

### DIFF
--- a/vaadin-spring-tests/test-spring-security-fusion/src/main/java/com/vaadin/flow/spring/fusionsecurity/Application.java
+++ b/vaadin-spring-tests/test-spring-security-fusion/src/main/java/com/vaadin/flow/spring/fusionsecurity/Application.java
@@ -1,9 +1,15 @@
 package com.vaadin.flow.spring.fusionsecurity;
 
+import com.vaadin.flow.component.dependency.NpmPackage;
+
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
+@NpmPackage(value = "@adobe/lit-mobx",
+            version = "2.0.0-rc.4")
+@NpmPackage(value = "mobx",
+            version = "^6.1.5")
 public class Application {
 
     public static void main(String[] args) {


### PR DESCRIPTION
Fixes CI build.
`mobx` deps were removed from Fusion tasks(https://github.com/vaadin/flow/pull/11651), so adding those throw `@NpmPackage` instead for the Fusion security tests.