### PR TITLE
test: lock mobx to 6.3.3

### DIFF
--- a/vaadin-spring-tests/test-spring-security-fusion/frontend/views/view.ts
+++ b/vaadin-spring-tests/test-spring-security-fusion/frontend/views/view.ts
@@ -12,7 +12,7 @@ export class MobxElement extends MobxLitElement {
   protected reaction<T>(
     expression: (r: IReactionPublic) => T,
     effect: (arg: T, prev: T, r: IReactionPublic) => void,
-    opts?: IReactionOptions
+    opts?: IReactionOptions<T>
   ): void {
     this.disposers.push(reaction(expression, effect, opts));
   }

--- a/vaadin-spring-tests/test-spring-security-fusion/src/main/java/com/vaadin/flow/spring/fusionsecurity/Application.java
+++ b/vaadin-spring-tests/test-spring-security-fusion/src/main/java/com/vaadin/flow/spring/fusionsecurity/Application.java
@@ -9,7 +9,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 @NpmPackage(value = "@adobe/lit-mobx",
             version = "2.0.0-rc.4")
 @NpmPackage(value = "mobx",
-            version = "6.1.5")
+            version = "^6.1.5")
 public class Application {
 
     public static void main(String[] args) {

--- a/vaadin-spring-tests/test-spring-security-fusion/src/main/java/com/vaadin/flow/spring/fusionsecurity/Application.java
+++ b/vaadin-spring-tests/test-spring-security-fusion/src/main/java/com/vaadin/flow/spring/fusionsecurity/Application.java
@@ -9,7 +9,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 @NpmPackage(value = "@adobe/lit-mobx",
             version = "2.0.0-rc.4")
 @NpmPackage(value = "mobx",
-            version = "^6.1.5")
+            version = "6.3.3")
 public class Application {
 
     public static void main(String[] args) {


### PR DESCRIPTION
Reverts vaadin/spring#892

Why would we want to stay on an old version?