### PR TITLE
chore: add confirm-dialog to get correct versions

### DIFF
--- a/vaadin-spring-tests/pom.xml
+++ b/vaadin-spring-tests/pom.xml
@@ -181,6 +181,11 @@
                 <artifactId>vaadin-form-layout-flow</artifactId>
                 <version>${vaadin.version}</version>
             </dependency>
+            <dependency>
+                <groupId>com.vaadin</groupId>
+                <artifactId>vaadin-confirm-dialog-flow</artifactId>
+                <version>${vaadin.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/vaadin-spring-tests/test-spring-security-fusion/pom.xml
+++ b/vaadin-spring-tests/test-spring-security-fusion/pom.xml
@@ -71,6 +71,10 @@
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-confirm-dialog-flow</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
             <artifactId>vaadin-checkbox-flow</artifactId>
         </dependency>
         <dependency>


### PR DESCRIPTION
rich-text-editor depends on confirm-dialog
but with a ^ on the js side so without the
dependency we can get components updated
to the wrong version.

