### PR TITLE
refactor: disable view access checker explicitly via new CTOR

### DIFF
--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/SpringSecurityAutoConfiguration.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/SpringSecurityAutoConfiguration.java
@@ -68,7 +68,7 @@ public class SpringSecurityAutoConfiguration {
      */
     @Bean
     public ViewAccessChecker viewAccessChecker() {
-        return new ViewAccessChecker();
+        return new ViewAccessChecker(false);
     }
 
     /**


### PR DESCRIPTION
## Description

Uses another view access checker CTOR for disabling access checker by default.

Related-to https://github.com/vaadin/flow/issues/11231

## Type of change

- [ ] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
