### PR TITLE
feat: Always use the security context from VaadinSession when one is available

### DIFF
--- a/vaadin-spring-tests/pom.xml
+++ b/vaadin-spring-tests/pom.xml
@@ -58,6 +58,16 @@
             </dependency>
             <dependency>
                 <groupId>com.vaadin</groupId>
+                <artifactId>vaadin-dialog-flow</artifactId>
+                <version>${vaadin.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.vaadin</groupId>
+                <artifactId>vaadin-notification-flow</artifactId>
+                <version>${vaadin.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.vaadin</groupId>
                 <artifactId>vaadin-ordered-layout-flow</artifactId>
                 <version>${vaadin.version}</version>
             </dependency>

--- a/vaadin-spring-tests/test-spring-security-flow/pom.xml
+++ b/vaadin-spring-tests/test-spring-security-flow/pom.xml
@@ -38,7 +38,19 @@
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-text-field-flow</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
             <artifactId>vaadin-upload-flow</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-dialog-flow</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-notification-flow</artifactId>
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>

--- a/vaadin-spring-tests/test-spring-security-flow/src/main/java/com/vaadin/flow/spring/flowsecurity/SecurityUtils.java
+++ b/vaadin-spring-tests/test-spring-security-flow/src/main/java/com/vaadin/flow/spring/flowsecurity/SecurityUtils.java
@@ -22,6 +22,12 @@ public class SecurityUtils {
 
     public UserDetails getAuthenticatedUser() {
         SecurityContext context = SecurityContextHolder.getContext();
+        if (context == null) {
+            throw new IllegalStateException("No security context available");
+        }
+        if (context.getAuthentication() == null) {
+            return null;
+        }
         Object principal = context.getAuthentication().getPrincipal();
         if (principal instanceof UserDetails) {
             UserDetails userDetails = (UserDetails) context.getAuthentication()

--- a/vaadin-spring-tests/test-spring-security-flow/src/main/java/com/vaadin/flow/spring/flowsecurity/service/BankService.java
+++ b/vaadin-spring-tests/test-spring-security-flow/src/main/java/com/vaadin/flow/spring/flowsecurity/service/BankService.java
@@ -19,13 +19,25 @@ public class BankService {
     private SecurityUtils utils;
 
     public void applyForLoan() {
+        applyForLoan(10000);
+    }
+
+    public void applyForHugeLoan() {
+        applyForLoan(1000000);
+        try {
+            Thread.sleep(3000);
+        } catch (InterruptedException e) {
+        }
+    }
+
+    private void applyForLoan(int amount) {
         String name = utils.getAuthenticatedUser().getUsername();
         Optional<Account> acc = accountRepository.findByOwner(name);
         if (!acc.isPresent()) {
             return;
         }
         Account account = acc.get();
-        account.setBalance(account.getBalance().add(new BigDecimal("10000")));
+        account.setBalance(account.getBalance().add(new BigDecimal(amount)));
         accountRepository.save(account);
     }
 
@@ -34,4 +46,5 @@ public class BankService {
         return accountRepository.findByOwner(name).map(Account::getBalance)
                 .orElse(null);
     }
+
 }

--- a/vaadin-spring-tests/test-spring-security-flow/src/main/java/com/vaadin/flow/spring/flowsecurity/views/Broadcaster.java
+++ b/vaadin-spring-tests/test-spring-security-flow/src/main/java/com/vaadin/flow/spring/flowsecurity/views/Broadcaster.java
@@ -1,0 +1,31 @@
+package com.vaadin.flow.spring.flowsecurity.views;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.ComponentEvent;
+import com.vaadin.flow.component.ComponentEventBus;
+import com.vaadin.flow.component.ComponentEventListener;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.shared.Registration;
+
+public class Broadcaster {
+
+    private static Broadcaster instance = new Broadcaster();
+
+    private ComponentEventBus router = new ComponentEventBus(new Div());
+
+    public static class RefreshEvent extends ComponentEvent<Component> {
+        public RefreshEvent() {
+            super(new Div(), false);
+        }
+    }
+
+    public static void sendMessage() {
+        instance.router.fireEvent(new RefreshEvent());
+    }
+
+    public static Registration addMessageListener(
+            ComponentEventListener<RefreshEvent> listener) {
+        return instance.router.addListener(RefreshEvent.class, listener);
+    }
+
+}

--- a/vaadin-spring-tests/test-spring-security-flow/src/main/java/com/vaadin/flow/spring/flowsecurity/views/Broadcaster.java
+++ b/vaadin-spring-tests/test-spring-security-flow/src/main/java/com/vaadin/flow/spring/flowsecurity/views/Broadcaster.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2000-2021 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package com.vaadin.flow.spring.flowsecurity.views;
 
 import com.vaadin.flow.component.Component;

--- a/vaadin-spring-tests/test-spring-security-flow/src/test/java/com/vaadin/flow/spring/flowsecurity/AbstractIT.java
+++ b/vaadin-spring-tests/test-spring-security-flow/src/test/java/com/vaadin/flow/spring/flowsecurity/AbstractIT.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2000-2021 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package com.vaadin.flow.spring.flowsecurity;
 
 import com.vaadin.flow.component.login.testbench.LoginFormElement;

--- a/vaadin-spring-tests/test-spring-security-flow/src/test/java/com/vaadin/flow/spring/flowsecurity/AbstractIT.java
+++ b/vaadin-spring-tests/test-spring-security-flow/src/test/java/com/vaadin/flow/spring/flowsecurity/AbstractIT.java
@@ -5,6 +5,7 @@ import com.vaadin.flow.component.login.testbench.LoginOverlayElement;
 import com.vaadin.flow.testutil.ChromeBrowserTest;
 import com.vaadin.testbench.TestBenchElement;
 
+import org.junit.After;
 import org.junit.Assert;
 import org.openqa.selenium.WebDriver;
 
@@ -12,6 +13,31 @@ public abstract class AbstractIT extends ChromeBrowserTest {
 
     private static final String ROOT_PAGE_HEADER_TEXT = "Welcome to the Java Bank of Vaadin";
     private static final String ANOTHER_PUBLIC_PAGE_HEADER_TEXT = "Another public view for testing";
+    private static final int SERVER_PORT = 8888;
+
+    @Override
+    protected int getDeploymentPort() {
+        return SERVER_PORT;
+    }
+
+    @Override
+    protected String getRootURL() {
+        return super.getRootURL(); // + "/context";
+    }
+
+    @After
+    public void tearDown() {
+        if (getDriver() != null) {
+            checkForBrowserErrors();
+        }
+    }
+
+    private void checkForBrowserErrors() {
+        checkLogsForErrors(msg -> {
+            return msg.contains(
+                    "admin-only/secret.txt - Failed to load resource: the server responded with a status of 403");
+        });
+    }
 
     protected void open(String path) {
         open(path, getDriver());

--- a/vaadin-spring-tests/test-spring-security-flow/src/test/java/com/vaadin/flow/spring/flowsecurity/AbstractIT.java
+++ b/vaadin-spring-tests/test-spring-security-flow/src/test/java/com/vaadin/flow/spring/flowsecurity/AbstractIT.java
@@ -1,0 +1,81 @@
+package com.vaadin.flow.spring.flowsecurity;
+
+import com.vaadin.flow.component.login.testbench.LoginFormElement;
+import com.vaadin.flow.component.login.testbench.LoginOverlayElement;
+import com.vaadin.flow.testutil.ChromeBrowserTest;
+import com.vaadin.testbench.TestBenchElement;
+
+import org.junit.Assert;
+import org.openqa.selenium.WebDriver;
+
+public abstract class AbstractIT extends ChromeBrowserTest {
+
+    private static final String ROOT_PAGE_HEADER_TEXT = "Welcome to the Java Bank of Vaadin";
+    private static final String ANOTHER_PUBLIC_PAGE_HEADER_TEXT = "Another public view for testing";
+
+    protected void open(String path) {
+        open(path, getDriver());
+    }
+
+    protected void open(String path, WebDriver driver) {
+        driver.get(getRootURL() + "/" + path);
+    }
+
+    protected void loginUser() {
+        login("john", "john");
+    }
+
+    protected void loginAdmin() {
+        login("emma", "emma");
+    }
+
+    protected void login(String username, String password) {
+        assertLoginViewShown();
+
+        LoginFormElement form = $(LoginOverlayElement.class).first()
+                .getLoginForm();
+        form.getUsernameField().setValue(username);
+        form.getPasswordField().setValue(password);
+        form.submit();
+        waitUntilNot(driver -> $(LoginOverlayElement.class).exists());
+    }
+
+    protected void assertLoginViewShown() {
+        assertPathShown("login");
+        waitUntil(driver -> $(LoginOverlayElement.class).exists());
+    }
+
+    protected void assertRootPageShown() {
+        waitUntil(drive -> $("h1").attribute("id", "header").exists());
+        String headerText = $("h1").id("header").getText();
+        Assert.assertEquals(ROOT_PAGE_HEADER_TEXT, headerText);
+    }
+
+    protected void assertAnotherPublicPageShown() {
+        waitUntil(drive -> $("h1").attribute("id", "header").exists());
+        String headerText = $("h1").id("header").getText();
+        Assert.assertEquals(ANOTHER_PUBLIC_PAGE_HEADER_TEXT, headerText);
+    }
+
+    protected void assertPrivatePageShown(String fullName) {
+        assertPathShown("protected");
+        waitUntil(driver -> $("span").attribute("id", "balanceText").exists());
+        String balance = $("span").id("balanceText").getText();
+        Assert.assertTrue(balance.startsWith(
+                "Hello " + fullName + ", your bank account balance is $"));
+    }
+
+    protected void assertAdminPageShown(String fullName) {
+        assertPathShown("admin");
+        TestBenchElement welcome = waitUntil(driver -> $("*").id("welcome"));
+        String welcomeText = welcome.getText();
+        Assert.assertEquals("Welcome to the admin page, " + fullName,
+                welcomeText);
+    }
+
+    protected void assertPathShown(String path) {
+        waitUntil(driver -> driver.getCurrentUrl()
+                .equals(getRootURL() + "/" + path));
+    }
+
+}

--- a/vaadin-spring-tests/test-spring-security-flow/src/test/java/com/vaadin/flow/spring/flowsecurity/AbstractIT.java
+++ b/vaadin-spring-tests/test-spring-security-flow/src/test/java/com/vaadin/flow/spring/flowsecurity/AbstractIT.java
@@ -84,7 +84,7 @@ public abstract class AbstractIT extends ChromeBrowserTest {
     }
 
     protected void assertPrivatePageShown(String fullName) {
-        assertPathShown("protected");
+        assertPathShown("private");
         waitUntil(driver -> $("span").attribute("id", "balanceText").exists());
         String balance = $("span").id("balanceText").getText();
         Assert.assertTrue(balance.startsWith(

--- a/vaadin-spring-tests/test-spring-security-flow/src/test/java/com/vaadin/flow/spring/flowsecurity/AppViewIT.java
+++ b/vaadin-spring-tests/test-spring-security-flow/src/test/java/com/vaadin/flow/spring/flowsecurity/AppViewIT.java
@@ -9,10 +9,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import com.vaadin.flow.component.button.testbench.ButtonElement;
-import com.vaadin.flow.component.login.testbench.LoginFormElement;
-import com.vaadin.flow.component.login.testbench.LoginOverlayElement;
 import com.vaadin.flow.component.upload.testbench.UploadElement;
-import com.vaadin.flow.testutil.ChromeBrowserTest;
 import com.vaadin.testbench.TestBenchElement;
 
 import org.apache.commons.io.IOUtils;
@@ -20,10 +17,8 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
 
-public class AppViewIT extends ChromeBrowserTest {
+public class AppViewIT extends AbstractIT {
 
-    private static final String ROOT_PAGE_HEADER_TEXT = "Welcome to the Java Bank of Vaadin";
-    private static final String ANOTHER_PUBLIC_PAGE_HEADER_TEXT = "Another public view for testing";
     private static final int SERVER_PORT = 8888;
     private static final String USER_FULLNAME = "John the User";
     private static final String ADMIN_FULLNAME = "Emma the Admin";
@@ -63,10 +58,6 @@ public class AppViewIT extends ChromeBrowserTest {
 
     private void clickLogout() {
         getMainView().$(ButtonElement.class).id("logout").click();
-    }
-
-    private void open(String path) {
-        getDriver().get(getRootURL() + "/" + path);
     }
 
     @Test
@@ -295,63 +286,6 @@ public class AppViewIT extends ChromeBrowserTest {
 
     private TestBenchElement getMainView() {
         return waitUntil(driver -> $("*").id("main-view"));
-    }
-
-    private void assertLoginViewShown() {
-        assertPathShown("login");
-        waitUntil(driver -> $(LoginOverlayElement.class).exists());
-    }
-
-    private void assertRootPageShown() {
-        waitUntil(drive -> $("h1").attribute("id", "header").exists());
-        String headerText = $("h1").id("header").getText();
-        Assert.assertEquals(ROOT_PAGE_HEADER_TEXT, headerText);
-    }
-
-    private void assertAnotherPublicPageShown() {
-        waitUntil(drive -> $("h1").attribute("id", "header").exists());
-        String headerText = $("h1").id("header").getText();
-        Assert.assertEquals(ANOTHER_PUBLIC_PAGE_HEADER_TEXT, headerText);
-    }
-
-    private void assertPrivatePageShown(String fullName) {
-        assertPathShown("private");
-        waitUntil(driver -> $("span").attribute("id", "balanceText").exists());
-        String balance = $("span").id("balanceText").getText();
-        Assert.assertTrue(balance.startsWith(
-                "Hello " + fullName + ", your bank account balance is $"));
-    }
-
-    private void assertAdminPageShown(String fullName) {
-        assertPathShown("admin");
-        TestBenchElement welcome = waitUntil(driver -> $("*").id("welcome"));
-        String welcomeText = welcome.getText();
-        Assert.assertEquals("Welcome to the admin page, " + fullName,
-                welcomeText);
-    }
-
-    private void assertPathShown(String path) {
-        waitUntil(driver -> driver.getCurrentUrl()
-                .equals(getRootURL() + "/" + path));
-    }
-
-    private void loginUser() {
-        login("john", "john");
-    }
-
-    private void loginAdmin() {
-        login("emma", "emma");
-    }
-
-    private void login(String username, String password) {
-        assertLoginViewShown();
-
-        LoginFormElement form = $(LoginOverlayElement.class).first()
-                .getLoginForm();
-        form.getUsernameField().setValue(username);
-        form.getPasswordField().setValue(password);
-        form.submit();
-        waitUntilNot(driver -> $(LoginOverlayElement.class).exists());
     }
 
     private void refresh() {

--- a/vaadin-spring-tests/test-spring-security-flow/src/test/java/com/vaadin/flow/spring/flowsecurity/AppViewIT.java
+++ b/vaadin-spring-tests/test-spring-security-flow/src/test/java/com/vaadin/flow/spring/flowsecurity/AppViewIT.java
@@ -13,39 +13,13 @@ import com.vaadin.flow.component.upload.testbench.UploadElement;
 import com.vaadin.testbench.TestBenchElement;
 
 import org.apache.commons.io.IOUtils;
-import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
 
 public class AppViewIT extends AbstractIT {
 
-    private static final int SERVER_PORT = 8888;
     private static final String USER_FULLNAME = "John the User";
     private static final String ADMIN_FULLNAME = "Emma the Admin";
-
-    @Override
-    protected int getDeploymentPort() {
-        return SERVER_PORT;
-    }
-
-    @Override
-    protected String getRootURL() {
-        return super.getRootURL(); // + "/context";
-    }
-
-    @After
-    public void tearDown() {
-        if (getDriver() != null) {
-            checkForBrowserErrors();
-        }
-    }
-
-    private void checkForBrowserErrors() {
-        checkLogsForErrors(msg -> {
-            return msg.contains(
-                    "admin-only/secret.txt - Failed to load resource: the server responded with a status of 403");
-        });
-    }
 
     private void logout() {
         if (!$(ButtonElement.class).attribute("id", "logout").exists()) {

--- a/vaadin-spring-tests/test-spring-security-flow/src/test/java/com/vaadin/flow/spring/flowsecurity/UIAccessContextIT.java
+++ b/vaadin-spring-tests/test-spring-security-flow/src/test/java/com/vaadin/flow/spring/flowsecurity/UIAccessContextIT.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2000-2021 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package com.vaadin.flow.spring.flowsecurity;
 
 import com.vaadin.flow.component.button.testbench.ButtonElement;

--- a/vaadin-spring-tests/test-spring-security-flow/src/test/java/com/vaadin/flow/spring/flowsecurity/UIAccessContextIT.java
+++ b/vaadin-spring-tests/test-spring-security-flow/src/test/java/com/vaadin/flow/spring/flowsecurity/UIAccessContextIT.java
@@ -9,7 +9,6 @@ import com.vaadin.testbench.TestBenchElement;
 
 import org.junit.Assert;
 import org.junit.Test;
-import org.openqa.selenium.By;
 import org.openqa.selenium.SearchContext;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.chrome.ChromeDriver;

--- a/vaadin-spring-tests/test-spring-security-flow/src/test/java/com/vaadin/flow/spring/flowsecurity/UIAccessContextIT.java
+++ b/vaadin-spring-tests/test-spring-security-flow/src/test/java/com/vaadin/flow/spring/flowsecurity/UIAccessContextIT.java
@@ -4,59 +4,56 @@ import com.vaadin.flow.component.button.testbench.ButtonElement;
 import com.vaadin.flow.component.login.testbench.LoginFormElement;
 import com.vaadin.flow.component.login.testbench.LoginOverlayElement;
 import com.vaadin.testbench.HasElementQuery;
-import com.vaadin.testbench.TestBench;
 import com.vaadin.testbench.TestBenchElement;
 
 import org.junit.Assert;
 import org.junit.Test;
 import org.openqa.selenium.SearchContext;
 import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.chrome.ChromeDriver;
-import org.openqa.selenium.chrome.ChromeOptions;
 
 public class UIAccessContextIT extends AbstractIT {
 
-    private WebDriver createHeadlessChromeDriver() {
-        ChromeOptions headlessOptions = new ChromeOptions();
-        headlessOptions.addArguments("--headless", "--disable-gpu");
-        return TestBench.createDriver(new ChromeDriver(headlessOptions));
-    }
-
     @Test
-    public void securityContextSetForUIAccess() {
+    public void securityContextSetForUIAccess() throws Exception {
         String expectedUserBalance = "Hello John the User, your bank account balance is $10000.00.";
         String expectedAdminBalance = "Hello Emma the Admin, your bank account balance is $200000.00.";
 
-        open("private");
-        loginUser();
-        TestBenchElement balance = $("span").id("balanceText");
-        Assert.assertEquals(expectedUserBalance, balance.getText());
+        WebDriver adminBrowser = getDriver();
+        try {
+            super.setup();
+            open("private");
+            loginUser();
+            TestBenchElement balance = $("span").id("balanceText");
+            Assert.assertEquals(expectedUserBalance, balance.getText());
 
-        WebDriver adminBrowser = createHeadlessChromeDriver();
-        open("private", adminBrowser);
-        HasElementQuery adminContext = new HasElementQuery() {
+            open("private", adminBrowser);
+            HasElementQuery adminContext = new HasElementQuery() {
 
-            @Override
-            public SearchContext getContext() {
-                return adminBrowser;
-            }
+                @Override
+                public SearchContext getContext() {
+                    return adminBrowser;
+                }
 
-        };
-        loginAdmin(adminContext);
-        TestBenchElement adminBalance = adminContext.$("span")
-                .id("balanceText");
-        Assert.assertEquals(expectedAdminBalance, adminBalance.getText());
+            };
+            loginAdmin(adminContext);
+            TestBenchElement adminBalance = adminContext.$("span")
+                    .id("balanceText");
+            Assert.assertEquals(expectedAdminBalance, adminBalance.getText());
 
-        ButtonElement sendRefresh = $(ButtonElement.class).id("sendRefresh");
-        sendRefresh.click();
-        Assert.assertEquals(expectedUserBalance, balance.getText());
-        Assert.assertEquals(expectedAdminBalance, adminBalance.getText());
+            ButtonElement sendRefresh = $(ButtonElement.class)
+                    .id("sendRefresh");
+            sendRefresh.click();
+            Assert.assertEquals(expectedUserBalance, balance.getText());
+            Assert.assertEquals(expectedAdminBalance, adminBalance.getText());
 
-        ButtonElement adminSendRefresh = adminContext.$(ButtonElement.class)
-                .id("sendRefresh");
-        adminSendRefresh.click();
-        Assert.assertEquals(expectedUserBalance, balance.getText());
-        Assert.assertEquals(expectedAdminBalance, adminBalance.getText());
+            ButtonElement adminSendRefresh = adminContext.$(ButtonElement.class)
+                    .id("sendRefresh");
+            adminSendRefresh.click();
+            Assert.assertEquals(expectedUserBalance, balance.getText());
+            Assert.assertEquals(expectedAdminBalance, adminBalance.getText());
+        } finally {
+            adminBrowser.quit();
+        }
     }
 
     private void loginAdmin(HasElementQuery adminContext) {

--- a/vaadin-spring-tests/test-spring-security-flow/src/test/java/com/vaadin/flow/spring/flowsecurity/UIAccessContextIT.java
+++ b/vaadin-spring-tests/test-spring-security-flow/src/test/java/com/vaadin/flow/spring/flowsecurity/UIAccessContextIT.java
@@ -1,0 +1,71 @@
+package com.vaadin.flow.spring.flowsecurity;
+
+import com.vaadin.flow.component.button.testbench.ButtonElement;
+import com.vaadin.flow.component.login.testbench.LoginFormElement;
+import com.vaadin.flow.component.login.testbench.LoginOverlayElement;
+import com.vaadin.testbench.HasElementQuery;
+import com.vaadin.testbench.TestBench;
+import com.vaadin.testbench.TestBenchElement;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.SearchContext;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.chrome.ChromeDriver;
+import org.openqa.selenium.chrome.ChromeOptions;
+
+public class UIAccessContextIT extends AbstractIT {
+
+    private WebDriver createHeadlessChromeDriver() {
+        ChromeOptions headlessOptions = new ChromeOptions();
+        headlessOptions.addArguments("--headless", "--disable-gpu");
+        return TestBench.createDriver(new ChromeDriver(headlessOptions));
+    }
+
+    @Test
+    public void securityContextSetForUIAccess() {
+        String expectedUserBalance = "Hello John the User, your bank account balance is $10000.00.";
+        String expectedAdminBalance = "Hello Emma the Admin, your bank account balance is $200000.00.";
+
+        open("private");
+        loginUser();
+        TestBenchElement balance = $("span").id("balanceText");
+        Assert.assertEquals(expectedUserBalance, balance.getText());
+
+        WebDriver adminBrowser = createHeadlessChromeDriver();
+        open("private", adminBrowser);
+        HasElementQuery adminContext = new HasElementQuery() {
+
+            @Override
+            public SearchContext getContext() {
+                return adminBrowser;
+            }
+
+        };
+        loginAdmin(adminContext);
+        TestBenchElement adminBalance = adminContext.$("span")
+                .id("balanceText");
+        Assert.assertEquals(expectedAdminBalance, adminBalance.getText());
+
+        ButtonElement sendRefresh = $(ButtonElement.class).id("sendRefresh");
+        sendRefresh.click();
+        Assert.assertEquals(expectedUserBalance, balance.getText());
+        Assert.assertEquals(expectedAdminBalance, adminBalance.getText());
+
+        ButtonElement adminSendRefresh = adminContext.$(ButtonElement.class)
+                .id("sendRefresh");
+        adminSendRefresh.click();
+        Assert.assertEquals(expectedUserBalance, balance.getText());
+        Assert.assertEquals(expectedAdminBalance, adminBalance.getText());
+    }
+
+    private void loginAdmin(HasElementQuery adminContext) {
+        LoginFormElement form = adminContext.$(LoginOverlayElement.class)
+                .first().getLoginForm();
+        form.getUsernameField().setValue("emma");
+        form.getPasswordField().setValue("emma");
+        form.submit();
+    }
+
+}

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/VaadinAwareSecurityContextHolderStrategy.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/VaadinAwareSecurityContextHolderStrategy.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2000-2021 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package com.vaadin.flow.spring.security;
 
 import com.vaadin.flow.server.VaadinSession;

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/VaadinAwareSecurityContextHolderStrategy.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/VaadinAwareSecurityContextHolderStrategy.java
@@ -1,0 +1,69 @@
+package com.vaadin.flow.spring.security;
+
+import com.vaadin.flow.server.VaadinSession;
+import org.springframework.lang.NonNull;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolderStrategy;
+import org.springframework.security.core.context.SecurityContextImpl;
+import org.springframework.security.web.context.HttpSessionSecurityContextRepository;
+
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+public final class VaadinAwareSecurityContextHolderStrategy
+        implements SecurityContextHolderStrategy {
+
+    private final ThreadLocal<SecurityContext> contextHolder = new ThreadLocal<>();
+
+    @Override
+    public void clearContext() {
+        contextHolder.remove();
+    }
+
+    @Override
+    @NonNull
+    public SecurityContext getContext() {
+        // We must prefer the vaadin session information over the threadlocal as
+        // it is
+        // more specific. It makes a huge difference if you for instance to
+        // `otherSessionUI.access` in a request thread. In this case the
+        // security
+        // context is expected to reflect the "otherSession" and not the current
+        // request.
+        //
+        SecurityContext context = getFromVaadinSession()
+                .orElseGet(() -> contextHolder.get());
+        if (context == null) {
+            context = createEmptyContext();
+            contextHolder.set(context);
+        }
+        return context;
+    }
+
+    @NonNull
+    private Optional<SecurityContext> getFromVaadinSession() {
+        VaadinSession session = VaadinSession.getCurrent();
+        if (session == null) {
+            return Optional.empty();
+        }
+        Object securityContext = session.getSession().getAttribute(
+                HttpSessionSecurityContextRepository.SPRING_SECURITY_CONTEXT_KEY);
+        if (securityContext instanceof SecurityContext) {
+            return Optional.of((SecurityContext) securityContext);
+        } else {
+            return Optional.empty();
+        }
+    }
+
+    @Override
+    public void setContext(@NonNull SecurityContext securityContext) {
+        contextHolder.set(requireNonNull(securityContext));
+    }
+
+    @Override
+    @NonNull
+    public SecurityContext createEmptyContext() {
+        return new SecurityContextImpl();
+    }
+}

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/VaadinAwareSecurityContextHolderStrategy.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/VaadinAwareSecurityContextHolderStrategy.java
@@ -26,6 +26,13 @@ import java.util.Optional;
 
 import static java.util.Objects.requireNonNull;
 
+/**
+ * A strategy that uses an available VaadinSession for retrieving the security
+ * context.
+ * <p>
+ * Falls back to the default thread specific security context when no
+ * vaadinSession is available.
+ */
 public final class VaadinAwareSecurityContextHolderStrategy
         implements SecurityContextHolderStrategy {
 
@@ -39,14 +46,13 @@ public final class VaadinAwareSecurityContextHolderStrategy
     @Override
     @NonNull
     public SecurityContext getContext() {
-        // We must prefer the vaadin session information over the threadlocal as
-        // it is
-        // more specific. It makes a huge difference if you for instance to
-        // `otherSessionUI.access` in a request thread. In this case the
-        // security
-        // context is expected to reflect the "otherSession" and not the current
-        // request.
-        //
+        /*
+         * We prefer the vaadin session information over the threadlocal as it
+         * is more specific. It makes a huge difference if you for instance to
+         * `otherSessionUI.access` in a request thread. In this case the
+         * security context is expected to reflect the "otherSession" and not
+         * the current request.
+         */
         SecurityContext context = getFromVaadinSession()
                 .orElseGet(() -> contextHolder.get());
         if (context == null) {

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/VaadinWebSecurityConfigurerAdapter.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/VaadinWebSecurityConfigurerAdapter.java
@@ -32,6 +32,7 @@ import org.springframework.security.config.annotation.web.builders.WebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.config.annotation.web.configurers.ExpressionUrlAuthorizationConfigurer;
 import org.springframework.security.config.annotation.web.configurers.FormLoginConfigurer;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 import org.springframework.security.web.util.matcher.OrRequestMatcher;
 import org.springframework.security.web.util.matcher.RequestMatcher;
@@ -85,6 +86,11 @@ public abstract class VaadinWebSecurityConfigurerAdapter
 
     @Override
     protected void configure(HttpSecurity http) throws Exception {
+        // Use a security context holder that can find the context from Vaadin
+        // specific classes
+        SecurityContextHolder.setStrategyName(
+                VaadinAwareSecurityContextHolderStrategy.class.getName());
+
         // Vaadin has its own CSRF protection.
         // Spring CSRF is not compatible with Vaadin internal requests
         http.csrf().ignoringRequestMatchers(

--- a/vaadin-spring/src/test/java/com/vaadin/flow/spring/SpringClassesSerializableTest.java
+++ b/vaadin-spring/src/test/java/com/vaadin/flow/spring/SpringClassesSerializableTest.java
@@ -88,6 +88,7 @@ public class SpringClassesSerializableTest extends ClassesSerializableTest {
                 "com\\.vaadin\\.flow\\.spring\\.scopes\\.VaadinSessionScope",
                 "com\\.vaadin\\.flow\\.spring\\.scopes\\.AbstractScope",
                 "com\\.vaadin\\.flow\\.spring\\.scopes\\.VaadinUIScope",
+                "com\\.vaadin\\.flow\\.spring\\.security\\.VaadinAwareSecurityContextHolderStrategy",
                 "com\\.vaadin\\.flow\\.spring\\.security\\.VaadinWebSecurityConfigurerAdapter",
                 "com\\.vaadin\\.flow\\.spring\\.security\\.VaadinDefaultRequestCache",
                 "com\\.vaadin\\.flow\\.spring\\.security\\.VaadinSavedRequestAwareAuthenticationSuccessHandler",


### PR DESCRIPTION
This ensures that the security context is the expected (the one from the UI you run access() on) if you run UI.access from a request to another VaadinSession.

Practical use case is e.g. sending a global 'refresh' event and the receipient updating the UI as a result.

Fixes #906
