### PR TITLE
Make vaadin.blacklisted-packages specifiable with packages

### DIFF
--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinServletContextInitializer.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinServletContextInitializer.java
@@ -558,7 +558,7 @@ public class VaadinServletContextInitializer
             neverScan = Collections.emptyList();
         } else {
             neverScan = Arrays.stream(neverScanProperty.split(","))
-                    .map(onlyFolder -> onlyFolder.replace('.', '/').trim())
+                    .map(pkg -> pkg.replace('.', '/').trim())
                     .collect(Collectors.toList());
         }
 

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinServletContextInitializer.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinServletContextInitializer.java
@@ -558,7 +558,8 @@ public class VaadinServletContextInitializer
             neverScan = Collections.emptyList();
         } else {
             neverScan = Arrays.stream(neverScanProperty.split(","))
-                    .map(String::trim).collect(Collectors.toList());
+                    .map(onlyFolder -> onlyFolder.replace('.', '/').trim())
+                    .collect(Collectors.toList());
         }
 
         String onlyScanProperty = appContext.getEnvironment()


### PR DESCRIPTION
Unlike `vaadin.whitelisted-packages` which can be specified with both '.' and '/', `vaadin.blacklisted-packages` only works with '/'. 
This is suboptimal, as rightly noted in this [issue](https://github.com/vaadin/starters/issues/34), because packages use . not /. 

