### PR TITLE
Updated Spring Boot to 2.6.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
 
         <!-- These are typically overridden with BOMs -->
         <vaadin.flow.version>10.0-SNAPSHOT</vaadin.flow.version>
-        <spring-boot.version>2.5.7</spring-boot.version>
+        <spring-boot.version>2.6.0</spring-boot.version>
 
         <!-- Additional manifest fields -->
         <Vaadin-License-Title>Apache License 2.0</Vaadin-License-Title>


### PR DESCRIPTION
Vaadin works fine with Spring Boot 2.6.0 (tested with actual Vaadin app). Our builds should always be made against the latest Spring Boot to react on possible breaking changes.