### PR TITLE
Add whitelisted-packages' docs URL to logs

### DIFF
--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinServletContextInitializer.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinServletContextInitializer.java
@@ -457,7 +457,7 @@ public class VaadinServletContextInitializer
                     .getProperty("vaadin.whitelisted-packages") == null) {
                 getLogger().info(
                         "Due to slow search it is recommended to use the whitelisted-packages feature to make scanning faster.\n\n"
-                                + "See 'Flow / Integrations / Using Vaadin with Spring / Vaadin Spring Configuration' topic 'Special configuration parameters' at https://vaadin.com/docs for more detailed information.");
+                                + "See the whitelisted-packages section in the docs at https://vaadin.com/docs/latest/flow/integrations/spring/configuration#special-configuration-parameters.");
             }
 
             try {

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinServletContextInitializer.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinServletContextInitializer.java
@@ -457,7 +457,7 @@ public class VaadinServletContextInitializer
                     .getProperty("vaadin.whitelisted-packages") == null) {
                 getLogger().info(
                         "Due to slow search it is recommended to use the whitelisted-packages feature to make scanning faster.\n\n"
-                                + "See the whitelisted-packages section in the docs at https://vaadin.com/docs/latest/flow/integrations/spring/configuration#special-configuration-parameters.");
+                                + "See the whitelisted-packages section in the docs at https://vaadin.com/docs/latest/flow/integrations/spring/configuration#special-configuration-parameters");
             }
 
             try {


### PR DESCRIPTION
When scanning is slow, specify the URL in the docs in which whitelisted-packages feature is discussed. 

This should be (1) easier for the developer than having to navigate to the relevant section themselves, and (2) more future-proof in case the structure of the docs changes (because usually there are redirects in place when the docs' structure is altered). 