### PR TITLE
Add spring-snapshots repo to pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
 
         <!-- These are typically overridden with BOMs -->
         <vaadin.flow.version>10.0-SNAPSHOT</vaadin.flow.version>
-        <spring-boot.version>2.5.7</spring-boot.version>
+        <spring-boot.version>2.6.2-SNAPSHOT</spring-boot.version>
 
         <!-- Additional manifest fields -->
         <Vaadin-License-Title>Apache License 2.0</Vaadin-License-Title>
@@ -263,6 +263,14 @@
                 <enabled>false</enabled>
             </snapshots>
         </repository>
+        <repository>
+            <id>spring-snapshots</id>
+            <name>Spring Snapshots</name>
+            <url>https://repo.spring.io/snapshot</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+        </repository>
     </repositories>
 
     <pluginRepositories>
@@ -281,6 +289,14 @@
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>
+        </pluginRepository>
+        <pluginRepository>
+            <id>spring-snapshots</id>
+            <name>Spring Snapshots</name>
+            <url>https://repo.spring.io/snapshot</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
         </pluginRepository>
         <pluginRepository>
             <id>vaadin-prereleases</id>

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
 
         <!-- These are typically overridden with BOMs -->
         <vaadin.flow.version>10.0-SNAPSHOT</vaadin.flow.version>
-        <spring-boot.version>2.6.2-SNAPSHOT</spring-boot.version>
+        <spring-boot.version>2.5.7</spring-boot.version>
 
         <!-- Additional manifest fields -->
         <Vaadin-License-Title>Apache License 2.0</Vaadin-License-Title>


### PR DESCRIPTION
Add `spring-snapshots` repo to pom in preparation to run nightly builds against Spring Boot snapshots in Team City. 