### PR TITLE
fix: add missing plugin version

### DIFF
--- a/vaadin-spring-tests/test-spring-boot-only-prepare/pom.xml
+++ b/vaadin-spring-tests/test-spring-boot-only-prepare/pom.xml
@@ -146,6 +146,7 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>${spring-boot.version}</version>
                 <configuration>
                     <maxAttempts>100</maxAttempts>
                     <wait>2500</wait>


### PR DESCRIPTION
Add the missing plugin version
to the no prepare test module
