### PR TITLE
fix: add default package to scan

### DIFF
--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinServletContextInitializer.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinServletContextInitializer.java
@@ -133,7 +133,10 @@ public class VaadinServletContextInitializer
      */
     private static final List<String> DEFAULT_SCAN_ONLY = Stream
             .of(Component.class.getPackage().getName(),
-                    Theme.class.getPackage().getName(), "com.vaadin.shrinkwrap")
+                    Theme.class.getPackage().getName(),
+                    // LitRenderer uses script annotation
+                    "com.vaadin.flow.data.renderer",
+                    "com.vaadin.shrinkwrap")
             .collect(Collectors.toList());
 
     /**


### PR DESCRIPTION
add the renderer package to also
be scanned always as LitRenderer
uses an annotation.

Fixes #1008
