### PR TITLE
chore: remove the duplicate version definition

### DIFF
--- a/vaadin-spring-boot-starter/pom.xml
+++ b/vaadin-spring-boot-starter/pom.xml
@@ -10,7 +10,6 @@
 
     <artifactId>vaadin-spring-boot-starter</artifactId>
     <name>Spring Boot Starter</name>
-    <version>10.0-SNAPSHOT</version>
     <description>
         Spring Boot Starter for Vaadin Flow applications.
     </description>


### PR DESCRIPTION
The starter module defined its own
version which was not updated.

Should just use the parent version.
