### PR TITLE
chore: remind Flow view must grant anonymous access if using setLoginView with path

### DIFF
--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/VaadinWebSecurityConfigurerAdapter.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/VaadinWebSecurityConfigurerAdapter.java
@@ -235,6 +235,11 @@ public abstract class VaadinWebSecurityConfigurerAdapter
      * This is used when your application uses a Fusion based login view
      * available at the given path.
      *
+     * NOTE: if the login path points to a Flow view, the corresponding java
+     * class must be annotated
+     * with @{@link com.vaadin.flow.server.auth.AnonymousAllowed} to ensure that
+     * the view is always accessible.
+     *
      * @param http
      *            the http security from {@link #configure(HttpSecurity)}
      * @param fusionLoginViewPath
@@ -253,6 +258,11 @@ public abstract class VaadinWebSecurityConfigurerAdapter
      * <p>
      * This is used when your application uses a Fusion based login view
      * available at the given path.
+     *
+     * NOTE: if the login path points to a Flow view, the corresponding java
+     * class must be annotated
+     * with @{@link com.vaadin.flow.server.auth.AnonymousAllowed} to ensure that
+     * the view is always accessible.
      *
      * @param http
      *            the http security from {@link #configure(HttpSecurity)}


### PR DESCRIPTION
If setLoginView is provided with a path to a Java Flow view, not accessible by anonymous users, when navigating to the login page the browser starts reloading the page infinitely.

This change updates javadoc to remind that the java class must be annotated with AnonymousAllowed.

Refs vaadin/flow#14582