### PR TITLE
chore: Unify dependencies, plugins, and configs with branch 1.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,16 @@
             <organization>Vaadin</organization>
             <email>petter@vaadin.com</email>
         </developer>
+        <developer>
+            <name>Patrik Lindström</name>
+            <organization>Vaadin</organization>
+            <email>patrik@vaadin.com</email>
+        </developer>
+        <developer>
+            <name>Anna Koskinen</name>
+            <organization>Vaadin</organization>
+            <email>anna@vaadin.com</email>
+        </developer>
     </developers>
     
     <properties>
@@ -86,11 +96,16 @@
         
         <!-- These are typically overridden with BOMs -->
         <vaadin.version>8.8.0</vaadin.version>
-        <spring.version>4.3.9.RELEASE</spring.version>
-        <spring.security.version>4.2.3.RELEASE</spring.security.version>
-        <spring.boot.version>1.4.7.RELEASE</spring.boot.version>
+        <spring.version>5.3.39</spring.version>
+        <spring.security.version>5.7.11</spring.security.version>
+        <spring.boot.version>2.7.18</spring.boot.version>
+        <mockito.version>3.12.4</mockito.version>
+        <javax.api.version>4.0.1</javax.api.version>
 
-        <slf4j.version>1.7.7</slf4j.version>
+        <!-- Additional dependency versions -->
+        <slf4j.version>2.0.16</slf4j.version>
+        <commons.logging.version>1.3.3</commons.logging.version>
+        <htmlunit.version>2.70.0</htmlunit.version>
 
         <!-- Additional manifest fields -->
         <Vaadin-License-Title>Apache License 2.0</Vaadin-License-Title>
@@ -98,8 +113,25 @@
         <junit.version>4.12</junit.version>
     </properties>
 
+    <dependencies>
+        <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+            <version>1.3.2</version>
+        </dependency>
+    </dependencies>
+
     <build>
         <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.13.0</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                    <encoding>UTF-8</encoding>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
@@ -124,7 +156,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>2.2.1</version>
+                <version>3.3.1</version>
                 <configuration>
                     <excludeResources>true</excludeResources>
                 </configuration>
@@ -140,7 +172,10 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.9</version>
+                <version>2.9.1</version>
+                <configuration>
+                    <source>8</source>
+                </configuration>
                 <executions>
                     <execution>
                         <phase>package</phase>
@@ -196,14 +231,24 @@
     </modules>
     <repositories>
         <repository>
-            <id>vaadin-snapshots</id>
-            <url>https://oss.sonatype.org/content/repositories/vaadin-snapshots/</url>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
+            <id>vaadin-addons</id>
+            <url>https://maven.vaadin.com/vaadin-addons</url>
+        </repository>
+        <repository>
+            <id>vaadin-prereleases</id>
+            <name>Vaadin Pre-releases</name>
+            <url>https://maven.vaadin.com/vaadin-prereleases</url>
         </repository>
     </repositories>
+    <profiles>
+        <profile>
+            <id>JDK11</id>
+            <activation>
+                <jdk>[11,)</jdk>
+            </activation>
+            <properties>
+                <maven.compiler.release>8</maven.compiler.release>
+            </properties>
+        </profile>
+    </profiles>
 </project>

--- a/vaadin-spring-boot-starter/pom.xml
+++ b/vaadin-spring-boot-starter/pom.xml
@@ -47,7 +47,7 @@
         <dependency>
             <groupId>net.sourceforge.htmlunit</groupId>
             <artifactId>htmlunit</artifactId>
-            <version>2.23</version>
+            <version>${htmlunit.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -56,7 +56,25 @@
             <version>${vaadin.version}</version>
             <scope>test</scope>
         </dependency>
-
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-spring</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-test</artifactId>
+            <version>${spring.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/vaadin-spring-boot-starter/src/test/java/com/vaadin/spring/web/TestStaticHttp.java
+++ b/vaadin-spring-boot-starter/src/test/java/com/vaadin/spring/web/TestStaticHttp.java
@@ -27,8 +27,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.context.embedded.LocalServerPort;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.context.annotation.Bean;
 import org.springframework.test.context.junit4.SpringRunner;
 

--- a/vaadin-spring-boot/pom.xml
+++ b/vaadin-spring-boot/pom.xml
@@ -63,8 +63,13 @@
         <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
-            <version>3.0.1</version>
+            <version>${javax.api.version}</version>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.3.1</version>
         </dependency>
 
         <!-- Test dependencies -->

--- a/vaadin-spring-security/pom.xml
+++ b/vaadin-spring-security/pom.xml
@@ -24,7 +24,7 @@
         <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
-            <version>3.0.1</version>
+            <version>${javax.api.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>
-            <version>1.2</version>
+            <version>${commons.logging.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -68,7 +68,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>1.9.5</version>
+            <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -78,7 +78,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>2.3.1</version>
+                <version>3.4.2</version>
                 <configuration>
                     <archive>
                         <manifest>

--- a/vaadin-spring/pom.xml
+++ b/vaadin-spring/pom.xml
@@ -24,12 +24,17 @@
         <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
-            <version>3.0.1</version>
+            <version>${javax.api.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-web</artifactId>
+            <version>${spring.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-context</artifactId>
             <version>${spring.version}</version>
         </dependency>
         <dependency>
@@ -57,7 +62,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>1.9.5</version>
+            <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
- Update list of developers
- Update Spring to 5.3.39
- Update Spring Security to 5.7.11
- Update Spring Boot to 2.7.18
- Update mockito to 3.12.4
- Update javax.api to 4.0.1
- Update slf4j to 2.0.16
- Update commons-logging to 1.3.3
- Update htmlunit to 2.70.0
- Update maven-source-plugin to 3.3.1
- Update maven-javadoc-plugin to 2.9.1 and add source config for Java 8
- Update repositories
- Update maven-jar-plugin to 3.4.2 for vaadin-spring-security
- Add javax.annotation-api dependency
- Add maven-compiler-plugin configs for Java 8 and UTF-8
- Add a profile for Java 11+ for Java 8 release target config
- Add spring-context dependency to vaadin-spring
- Add jaxb-api dependency to vaadin-spring-boot
- Add test dependencies to vaadin-spring-boot-starter
- Move version configurations to parent POM
- Change a test class to use the new location for Spring Boot's LocalServerPort