### PR TITLE
chore: Update plugins and dependencies (V7)

### DIFF
--- a/checkstyle/vaadin-checkstyle.xml
+++ b/checkstyle/vaadin-checkstyle.xml
@@ -140,9 +140,6 @@
 
         <!-- Checks for Size Violations. -->
         <!-- See http://checkstyle.sf.net/config_sizes.html -->
-        <module name="LineLength">
-            <property name="severity" value="warning" />
-        </module>
         <module name="MethodLength">
             <property name="severity" value="warning" />
         </module>
@@ -248,6 +245,10 @@
             <property name="format" value="System\.err\.println"/>
         </module>
 
+    </module>
+
+    <module name="LineLength">
+        <property name="severity" value="warning" />
     </module>
 
 </module>

--- a/pom.xml
+++ b/pom.xml
@@ -97,14 +97,14 @@
         <!-- These are typically overridden with BOMs -->
         <vaadin.version>7.7.44</vaadin.version>
         <spring.version>5.3.39</spring.version>
-        <spring.security.version>5.7.11</spring.security.version>
+        <spring.security.version>5.7.14</spring.security.version>
         <spring.boot.version>2.7.18</spring.boot.version>
-        <mockito.version>3.12.4</mockito.version>
+        <mockito.version>4.11.0</mockito.version>
         <javax.api.version>4.0.1</javax.api.version>
 
         <!-- Additional dependency versions -->
         <slf4j.version>2.0.16</slf4j.version>
-        <commons.logging.version>1.3.3</commons.logging.version>
+        <commons.logging.version>1.3.4</commons.logging.version>
         <htmlunit.version>2.70.0</htmlunit.version>
 
         <!-- Additional manifest fields -->
@@ -135,7 +135,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
-                <version>2.17</version>
+                <version>3.6.0</version>
                 <configuration>
                     <enableRulesSummary>false</enableRulesSummary>
                     <includeTestSourceDirectory>true</includeTestSourceDirectory>
@@ -172,7 +172,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.9.1</version>
+                <version>3.11.2</version>
                 <configuration>
                     <source>8</source>
                 </configuration>


### PR DESCRIPTION
- Spring Security to 5.7.14
- Mockito to 4.11.0
- commons-logging to 1.3.4
- maven-checkstyle-plugin to 3.6.0
- maven-javadoc-plugin to 3.11.2