### PR TITLE
Refactor getServletPath() and getPathInfo() for Conciseness

### DIFF
--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/ForwardingRequestWrapper.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/ForwardingRequestWrapper.java
@@ -42,24 +42,15 @@ public class ForwardingRequestWrapper extends HttpServletRequestWrapper {
 
     @Override
     public String getServletPath() {
-        String pathInfo = super.getPathInfo();
-        if (pathInfo == null) {
-            // the path where a ServletForwardingController is registered is not
-            // a real servlet path
-            return "";
-        } else {
-            return super.getServletPath();
-        }
+        return (super.getPathInfo() == null) ? super.getServletPath() : "";
+        // the path where a ServletForwardingController is registered is not
+        // a real servlet path
     }
 
     @Override
     public String getPathInfo() {
-        String pathInfo = super.getPathInfo();
-        if (pathInfo == null) {
-            // this uses getServletPath() and should work both with and without
-            // clearServletPath
-            pathInfo = urlPathHelper.getPathWithinServletMapping(this);
-        }
-        return pathInfo;
+        return (super.getPathInfo() == null) ? urlPathHelper.getPathWithinServletMapping(this) : super.getPathInfo();
+        // this uses getServletPath() and should work both with and without
+        // clearServletPath
     }
 }


### PR DESCRIPTION
#Description  
Refactored `getServletPath()` and `getPathInfo()` methods to use the *ternary operatorinstead* of `if-else`. This change improves *code conciseness* while maintaining the same functionality.  

#Type of change
- [ ] Bugfix  
- [✔] Feature (Code Improvement)  

#Checklist

- [✔] I have read the contribution guide: [[Vaadin Contribution Guide]
- [✔] I have added a description following the guideline.  
- [✔] The issue is created in the corresponding repository and I have referenced it.  
- [✔] I have added tests to ensure my change is effective and works as intended.  
- [✔] New and existing tests are passing locally with my change.  
- [✔] I have performed self-review and corrected misspellings.  

#Additional for `Feature` type of change
- [✔] Enhancement / new feature was discussed in a corresponding GitHub issue, and Acceptance Criteria were created.  

#Rationale for Change
- The ternary operator simplifies the code without altering its logic.  
- It eliminates unnecessary variable assignments while keeping the functionality intact.  
- The performance difference is negligible, and the new approach aligns with concise coding practices.  
