### PR TITLE
chore: Revert to Vaadin Parent 1.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-parent</artifactId>
-        <version>3.0.0</version>
+        <version>1.1.0</version>
     </parent>
 
     <artifactId>vaadin-spring-parent</artifactId>


### PR DESCRIPTION
Required for Maven Central deployment