### PR TITLE
fix: Improve authentication discovery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ target/
 .idea
 .checkstyle
 *.iml
+.vscode/settings.json

--- a/pom.xml
+++ b/pom.xml
@@ -98,13 +98,13 @@
         <!-- These are typically overridden with BOMs -->
         <jakarta.servlet.version>6.0.0</jakarta.servlet.version>
         <jakarta.annotation.version>2.1.1</jakarta.annotation.version>
-        <vaadin.version>8.23.0</vaadin.version>
+        <vaadin.version>8.31.1</vaadin.version>
         <spring.version>6.2.7</spring.version>
         <spring.boot.version>3.4.6</spring.boot.version>
         <spring.security.version>6.4.6</spring.security.version>
         <slf4j.version>2.0.17</slf4j.version>
         <junit.version>4.13.2</junit.version>
-        <mockito.version>5.11.0</mockito.version>
+        <mockito.version>5.23.0</mockito.version>
         <hamcrest.version>1.3</hamcrest.version>
         <h2.version>2.2.224</h2.version>
 

--- a/vaadin-spring-security/pom.xml
+++ b/vaadin-spring-security/pom.xml
@@ -58,6 +58,12 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-server-mpr-jakarta</artifactId>
+            <version>${vaadin.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <version>${slf4j.version}</version>

--- a/vaadin-spring-security/src/main/java/com/vaadin/spring/access/SecuredViewAccessControl.java
+++ b/vaadin-spring-security/src/main/java/com/vaadin/spring/access/SecuredViewAccessControl.java
@@ -19,6 +19,12 @@ import com.vaadin.navigator.View;
 import com.vaadin.spring.annotation.SpringComponent;
 import com.vaadin.spring.server.SpringVaadinServletService;
 import com.vaadin.ui.UI;
+import com.vaadin.server.VaadinRequest;
+import com.vaadin.server.VaadinService;
+import com.vaadin.server.VaadinServletRequest;
+
+import jakarta.servlet.http.HttpSession;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.springframework.core.annotation.AnnotationUtils;
@@ -27,8 +33,10 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.context.HttpSessionSecurityContextRepository;
 
 import java.io.Serializable;
+import java.security.Principal;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -57,16 +65,17 @@ public class SecuredViewAccessControl implements ViewAccessControl, Serializable
      * @see Secured
      */
     protected boolean isAccessGranted(String[] securityConfigAttributes) {
-        SecurityContext context = SecurityContextHolder.getContext();
-        Authentication authentication = context.getAuthentication();
+        Authentication authentication = resolveAuthentication();
         if (authentication == null) {
             return false;
         }
+
         Set<String> authorities = authentication.getAuthorities().stream()
                 .map(GrantedAuthority::getAuthority)
                 .collect(Collectors.toSet());
-        return
-                Stream.of(securityConfigAttributes).anyMatch(authorities::contains);
+
+        return Stream.of(securityConfigAttributes)
+            .anyMatch(authorities::contains);
     }
 
     /**
@@ -121,4 +130,32 @@ public class SecuredViewAccessControl implements ViewAccessControl, Serializable
 
         return applicationContext;
     }
+
+    private Authentication resolveAuthentication() {
+        SecurityContext context = SecurityContextHolder.getContext();
+        if (context != null && context.getAuthentication() != null) {
+            return context.getAuthentication();
+        }
+
+        VaadinRequest request = VaadinService.getCurrentRequest();
+        if (request instanceof VaadinServletRequest servletRequest) {
+            Principal principal = servletRequest.getUserPrincipal();
+            if (principal instanceof Authentication authentication) {
+                return authentication;
+            }
+
+            HttpSession session = servletRequest.getHttpServletRequest()
+                    .getSession(false);
+            if (session != null) {
+                Object securityContextAttribute = session.getAttribute(
+                        HttpSessionSecurityContextRepository.SPRING_SECURITY_CONTEXT_KEY);
+                if (securityContextAttribute instanceof SecurityContext securityContext) {
+                    return securityContext.getAuthentication();
+                }
+            }
+        }
+
+        return null;
+    }
+
 }


### PR DESCRIPTION
## Description

Secured Vaadin SpringViews would fail to load under normal discovery rules unless a custom SecuredViewAccessControl class was used, which performed additional heuristics to find a valid set of Authorities. This change discovers them from the current session context, negating the need for an overriding class.